### PR TITLE
Register stablehlo.round_nearest_even op

### DIFF
--- a/src/pjrt_plugin/ops/unary_ops.mm
+++ b/src/pjrt_plugin/ops/unary_ops.mm
@@ -71,6 +71,7 @@ REGISTER_MPS_OP("stablehlo.sign", Handle_sign);
 REGISTER_MLIR_UNARY_OP("stablehlo.is_finite", isFinite, is_finite);
 REGISTER_MLIR_UNARY_OP("chlo.square", square, chlo_square);
 REGISTER_MLIR_UNARY_OP("stablehlo.ceil", ceil, ceil);
+REGISTER_MLIR_UNARY_OP("stablehlo.round_nearest_even", rint, round_nearest_even);
 REGISTER_MLIR_UNARY_OP("stablehlo.cosine", cos, cosine);
 REGISTER_MLIR_UNARY_OP("stablehlo.sine", sin, sine);
 REGISTER_MLIR_UNARY_OP("stablehlo.tan", tan, tan);

--- a/tests/configs/unary.py
+++ b/tests/configs/unary.py
@@ -57,6 +57,7 @@ def make_unary_op_configs():
     yield from [
         OperationTestConfig(jnp.ceil, numpy.random.standard_normal((17,))),
         OperationTestConfig(jnp.floor, numpy.random.standard_normal((17,))),
+        OperationTestConfig(jnp.round, numpy.random.standard_normal((17,))),
     ]
 
     # Ops that don't trivially generalize across real/complex.


### PR DESCRIPTION
## Summary

- Register `stablehlo.round_nearest_even` mapped to MPS `rintWithTensor:` (banker's rounding)
- Add `jnp.round` test config

## Test plan

- [x] `jnp.round` value and gradient tests pass (jit + eager)
- [x] Full suite: 518 passed, 126 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)