### PR TITLE
Add issue template for missing ops and link from error messages

### DIFF
--- a/.github/ISSUE_TEMPLATE/missing-op.yml
+++ b/.github/ISSUE_TEMPLATE/missing-op.yml
@@ -1,0 +1,20 @@
+name: Missing operation
+description: Request support for a StableHLO/CHLO operation that is not yet implemented.
+labels: ["missing op"]
+body:
+  - type: input
+    id: op-name
+    attributes:
+      label: Operation name
+      description: The StableHLO or CHLO operation name from the error message.
+      placeholder: "stablehlo.example"
+    validations:
+      required: true
+  - type: textarea
+    id: code-snippet
+    attributes:
+      label: Code to reproduce
+      description: A minimal code snippet that triggers the missing operation error.
+      render: python
+    validations:
+      required: true

--- a/src/pjrt_plugin/issue_url.h
+++ b/src/pjrt_plugin/issue_url.h
@@ -1,0 +1,38 @@
+#ifndef ISSUE_URL_H
+#define ISSUE_URL_H
+
+#include <string>
+#include <vector>
+
+namespace jax_mps {
+
+/// Build a full error message for unsupported ops, including links to the
+/// GitHub issue template and CONTRIBUTING.md.
+inline std::string UnsupportedOpsMessage(const std::vector<std::string>& op_names) {
+    // Build comma-separated list of op names.
+    std::string op_list;
+    for (size_t i = 0; i < op_names.size(); i++) {
+        if (i > 0)
+            op_list += ", ";
+        op_list += op_names[i];
+    }
+
+    // URL-encode dots in the first op name for query parameters.
+    std::string encoded = op_names[0];
+    for (size_t pos = 0; (pos = encoded.find('.', pos)) != std::string::npos; pos += 3) {
+        encoded.replace(pos, 1, "%2E");
+    }
+
+    return "Unsupported operation(s): " + op_list +
+           ". The MPS backend does not have a handler for these operations.\n\n"
+           "File an issue: "
+           "https://github.com/tillahoffmann/jax-mps/issues/new?template=missing-op.yml"
+           "&title=Missing+op:+" +
+           encoded + "&op-name=" + encoded +
+           "\n"
+           "Add it yourself: https://github.com/tillahoffmann/jax-mps/blob/main/CONTRIBUTING.md";
+}
+
+}  // namespace jax_mps
+
+#endif  // ISSUE_URL_H

--- a/src/pjrt_plugin/mps_executable.mm
+++ b/src/pjrt_plugin/mps_executable.mm
@@ -6,6 +6,7 @@
 
 #include <unordered_map>
 
+#import "pjrt_plugin/issue_url.h"
 #import "pjrt_plugin/mps_buffer.h"
 #import "pjrt_plugin/mps_client.h"
 #import "pjrt_plugin/mps_device.h"
@@ -164,12 +165,10 @@ static ProcessResult processOperations(MPSGraph* graph, mlir::Block& block, Valu
         // Look up handler in registry
         OpHandler handler = OpRegistry::Find(op_name);
         if (!handler) {
-            std::string supported = OpRegistry::ListRegistered();
-            return ProcessResult::Error(
-                "Unsupported operation: '" + op_name +
-                "'. The MPS backend does not have a handler for this operation. "
-                "Supported operations: " +
-                supported);
+            return ProcessResult::Error(UnsupportedOpsMessage({op_name}) +
+                                        "\n\n"
+                                        "Supported operations: " +
+                                        OpRegistry::ListRegistered());
         }
 
         // Check for multi-result operations (not yet supported)

--- a/src/pjrt_plugin/pjrt_client.cc
+++ b/src/pjrt_plugin/pjrt_client.cc
@@ -2,6 +2,7 @@
 
 #include <cstring>
 
+#include "pjrt_plugin/issue_url.h"
 #include "pjrt_plugin/logging.h"
 #include "pjrt_plugin/pjrt_types.h"
 #include "pjrt_plugin/stablehlo_parser.h"
@@ -201,15 +202,7 @@ PJRT_Error* MPS_Client_Compile(PJRT_Client_Compile_Args* args) {
 
     // Check for unsupported operations discovered during parsing
     if (!parsed_module.unsupported_ops.empty()) {
-        std::string unsupported_list;
-        for (size_t i = 0; i < parsed_module.unsupported_ops.size(); i++) {
-            if (i > 0)
-                unsupported_list += ", ";
-            unsupported_list += parsed_module.unsupported_ops[i];
-        }
-        return MakeError("Program contains unsupported StableHLO operations: " + unsupported_list +
-                         ". "
-                         "The MPS backend does not yet implement these operations.");
+        return MakeError(jax_mps::UnsupportedOpsMessage(parsed_module.unsupported_ops));
     }
 
     // Compile the ParsedModule to MPS executable (takes ownership)


### PR DESCRIPTION
## Summary

- Add a GitHub issue form template (`.github/ISSUE_TEMPLATE/missing-op.yml`) for reporting missing ops, with fields for the op name and a code snippet.
- Update unsupported-op error messages to include a pre-filled link to the issue template and a link to `CONTRIBUTING.md`.
- Extract shared error message logic into `issue_url.h`, used by both the compile-time check (`pjrt_client.cc`) and the runtime fallback (`mps_executable.mm`).
- Add a test (`test_unsupported_op_error_message`) that triggers an unregistered op (`clz`) and asserts the error contains both links.

## Test plan

- [x] `test_unsupported_op_error_message` passes in both jit and eager modes
- [x] All pre-commit hooks pass (clang-format, ruff, pyright, build, pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)