### PR TITLE
ci: add dev releases on main and release script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,6 +140,43 @@ jobs:
           name: wheel-py${{ matrix.python }}
           path: dist/*.whl
 
+  publish-dev:
+    name: Publish dev release
+    needs: [lint-cpp, build-and-test]
+    runs-on: macos-14
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      id-token: write  # Required for PyPI trusted publishing
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+
+      - name: Restore deps from cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/.jax-mps-deps
+          key: mlir-stablehlo-v2-macos14-${{ hashFiles('scripts/setup_deps.sh') }}
+          fail-on-cache-miss: true
+
+      - name: Build dev wheel
+        run: |
+          # Extract base version and append dev suffix
+          BASE_VERSION=$(grep '^version' pyproject.toml | cut -d'"' -f2)
+          DEV_VERSION="${BASE_VERSION}.dev${{ github.run_number }}"
+          echo "Building version: $DEV_VERSION"
+          sed -i '' "s/^version = \".*\"/version = \"$DEV_VERSION\"/" pyproject.toml
+          uv build --wheel
+        env:
+          CMAKE_PREFIX_PATH: ${{ github.workspace }}/.jax-mps-deps
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
   release:
     name: Release
     needs: [lint-cpp, build-and-test]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jax-mps"
-version = "0.9.4"
+version = "0.9.5"
 description = "JAX backend for Apple Metal Performance Shaders (MPS)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -euo pipefail
+
+# Get current version from pyproject.toml
+CURRENT_VERSION=$(grep '^version' pyproject.toml | cut -d'"' -f2)
+TAG="v${CURRENT_VERSION}"
+
+echo "Current version: ${CURRENT_VERSION}"
+echo "Tag to create: ${TAG}"
+
+# Check for uncommitted changes
+if ! git diff --quiet || ! git diff --cached --quiet; then
+    echo "Error: uncommitted changes present. Commit or stash them first."
+    exit 1
+fi
+
+# Check we're on main
+BRANCH=$(git branch --show-current)
+if [[ "$BRANCH" != "main" ]]; then
+    echo "Error: not on main branch (currently on ${BRANCH})"
+    exit 1
+fi
+
+# Check tag doesn't already exist
+if git rev-parse "$TAG" >/dev/null 2>&1; then
+    echo "Error: tag ${TAG} already exists"
+    exit 1
+fi
+
+# Determine next version (bump patch)
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+NEXT_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+
+echo "Next version: ${NEXT_VERSION}"
+echo ""
+read -p "Proceed with release? [y/N] " -n 1 -r
+echo ""
+
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "Aborted."
+    exit 1
+fi
+
+# Create and push tag
+echo "Creating tag ${TAG}..."
+git tag -a "$TAG" -m "Release ${CURRENT_VERSION}"
+git push origin "$TAG"
+
+# Bump version
+echo "Bumping version to ${NEXT_VERSION}..."
+uv version "$NEXT_VERSION"
+
+# Commit and push version bump
+git add pyproject.toml uv.lock
+git commit -m "Bump version to ${NEXT_VERSION}"
+git push
+
+echo ""
+echo "Done! Release ${CURRENT_VERSION} is being built."
+echo "Watch progress at: https://github.com/tillahoffmann/jax-mps/actions"

--- a/uv.lock
+++ b/uv.lock
@@ -329,7 +329,7 @@ wheels = [
 
 [[package]]
 name = "jax-mps"
-version = "0.9.4"
+version = "0.9.5"
 source = { editable = "." }
 dependencies = [
     { name = "jax" },


### PR DESCRIPTION
## Summary
- Publish pre-release versions (`X.Y.Z.devN`) to PyPI on every push to main
- Add `scripts/release.sh` for creating tagged releases
- Bump version to 0.9.5 for next release cycle

## Usage

Install latest dev build:
```bash
pip install jax-mps --pre
```

Create a release:
```bash
./scripts/release.sh
```

## Note
You'll need to add a trusted publisher in PyPI for the `publish-dev` job (workflow: `build.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)