### PR TITLE
ci: refactor workflow to avoid skipped job cascade

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,9 +181,8 @@ jobs:
 
       - name: Install wheel and test dependencies
         run: |
-          uv venv
+          uv sync --all-groups --no-install-project
           uv pip install dist/*.whl
-          uv pip install pytest
 
       # MPS is not available on the runner yet.
       # https://docs.github.com/en/actions/reference/runners/github-hosted-runners#limitations-for-arm64-macos-runners


### PR DESCRIPTION
## Summary
- Merge `check-cache` and `build-deps` into single `setup-deps` job with step-level conditionals
- This avoids the GitHub Actions quirk where skipped jobs cause downstream jobs to skip
- Separate `build`, `lint`, and `test` into distinct parallel jobs
- Simplify to Python 3.13 only (no matrix)
- `build-dev` runs in parallel on main, `publish-dev` waits for `test` + `lint`

## New workflow structure
```
setup-deps (always succeeds)
    │
    ├───────────┬───────────┬───────────┐
    ▼           ▼           ▼           │
  build       lint      build-dev       │
    │                   (main only)     │
    ▼                       │           │
  test                      │           │
    │                       │           │
    ├───────────┴───────────┘           
    ▼           
 release (tag) / publish-dev (main)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)