### PR TITLE
ci: split lint into parallel lint-cpp and lint-python jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,17 +74,12 @@ jobs:
           name: wheel
           path: dist/*.whl
 
-  lint:
-    name: Lint
+  lint-cpp:
+    name: Lint C++
     needs: setup-deps
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          python-version: "3.13"
 
       - name: Restore deps from cache
         uses: actions/cache/restore@v4
@@ -110,6 +105,25 @@ jobs:
         run: |
           export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
           find src -type f \( -name "*.cc" -o -name "*.mm" \) ! -name "pjrt_executable.cc" | xargs -n 1 -P $(sysctl -n hw.ncpu) clang-tidy -p build
+
+  lint-python:
+    name: Lint Python
+    needs: setup-deps
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+
+      - name: Restore deps from cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/.jax-mps-deps
+          key: mlir-stablehlo-v2-macos14-${{ hashFiles('scripts/setup_deps.sh') }}
+          fail-on-cache-miss: true
 
       - name: Install project dependencies
         run: uv sync --all-groups
@@ -192,7 +206,7 @@ jobs:
 
   release:
     name: Release
-    needs: [test, lint]
+    needs: [test, lint-cpp, lint-python]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
@@ -216,7 +230,7 @@ jobs:
 
   publish-dev:
     name: Publish dev release
-    needs: [test, lint, build-dev]
+    needs: [test, lint-cpp, lint-python, build-dev]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     permissions:


### PR DESCRIPTION
## Summary
- Split `lint` job into `lint-cpp` and `lint-python` running in parallel
- Both start immediately after `setup-deps`
- Reduces overall CI time by running C++ and Python linting concurrently

## Updated workflow structure
```
setup-deps
    │
    ├────────────┬────────────┬────────────┬────────────┐
    ▼            ▼            ▼            ▼            │
  build      lint-cpp    lint-python   build-dev       │
    │                                  (main only)     │
    ▼                                      │           │
  test                                     │           │
    │                                      │           │
    ├────────────┴────────────┴────────────┘           
    ▼
 release (tag) / publish-dev (main)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)