### PR TITLE
Move flip/transpose tests from unary.py to shape.py

### DIFF
--- a/tests/configs/shape.py
+++ b/tests/configs/shape.py
@@ -1,11 +1,51 @@
 from jax import numpy as jnp
 
-from .util import OperationTestConfig
+from .util import OperationTestConfig, complex_standard_normal
 
 
 def make_shape_op_configs():
+    # Flip and transpose ops for both real and complex inputs
+    for complex in [False, True]:
+        with OperationTestConfig.module_name(
+            "shape-complex" if complex else "shape-real"
+        ):
+            yield from [
+                OperationTestConfig(
+                    jnp.flip,
+                    lambda rng, complex=complex: complex_standard_normal(
+                        rng, (17,), complex
+                    ),
+                ),
+                OperationTestConfig(
+                    jnp.fliplr,
+                    lambda rng, complex=complex: complex_standard_normal(
+                        rng, (17, 13), complex
+                    ),
+                ),
+                OperationTestConfig(
+                    jnp.flipud,
+                    lambda rng, complex=complex: complex_standard_normal(
+                        rng, (17, 13), complex
+                    ),
+                ),
+                OperationTestConfig(
+                    jnp.transpose,
+                    lambda rng, complex=complex: complex_standard_normal(
+                        rng, (17, 8, 9), complex
+                    ),
+                ),
+                OperationTestConfig(
+                    jnp.transpose,
+                    lambda rng, complex=complex: complex_standard_normal(
+                        rng, (17, 8, 9), complex
+                    ),
+                    (1, 0, 2),
+                    static_argnums=(1,),
+                ),
+            ]
+
     with OperationTestConfig.module_name("shape"):
-        return [
+        yield from [
             OperationTestConfig(
                 lambda x, y: jnp.concatenate([x, y], axis=0),
                 lambda rng: rng.normal(size=(3, 4)),

--- a/tests/configs/unary.py
+++ b/tests/configs/unary.py
@@ -31,25 +31,6 @@ def make_unary_op_configs():
                     ),
                 ),
                 OperationTestConfig(
-                    jnp.flip,
-                    lambda rng, complex=complex: complex_standard_normal(
-                        rng, (17,), complex
-                    ),
-                ),
-                # FIXME: Flip ops should probably be in './shape.py'.
-                OperationTestConfig(
-                    jnp.fliplr,
-                    lambda rng, complex=complex: complex_standard_normal(
-                        rng, (17, 13), complex
-                    ),
-                ),
-                OperationTestConfig(
-                    jnp.flipud,
-                    lambda rng, complex=complex: complex_standard_normal(
-                        rng, (17, 13), complex
-                    ),
-                ),
-                OperationTestConfig(
                     jnp.negative,
                     lambda rng, complex=complex: complex_standard_normal(
                         rng, (17,), complex
@@ -84,21 +65,6 @@ def make_unary_op_configs():
                     lambda rng, complex=complex: complex_standard_normal(
                         rng, (17,), complex
                     ),
-                ),
-                # FIXME: Transpose ops should probably live in './shape.py'.
-                OperationTestConfig(
-                    jnp.transpose,
-                    lambda rng, complex=complex: complex_standard_normal(
-                        rng, (17, 8, 9), complex
-                    ),
-                ),
-                OperationTestConfig(
-                    jnp.transpose,
-                    lambda rng, complex=complex: complex_standard_normal(
-                        rng, (17, 8, 9), complex
-                    ),
-                    (1, 0, 2),
-                    static_argnums=(1,),
                 ),
                 OperationTestConfig(
                     jnp.real,


### PR DESCRIPTION
## Summary

- Move `jnp.flip`, `jnp.fliplr`, `jnp.flipud`, and `jnp.transpose` tests from `tests/configs/unary.py` to `tests/configs/shape.py`
- These operations are shape manipulations, not unary math operations
- Resolves the FIXMEs that were in the code noting the misplacement

## Test plan

- [x] All pre-commit hooks pass (ruff, pyright, pytest)
- [x] Tests now run under `shape-real.*` and `shape-complex.*` module names
- [x] Verified flip/transpose tests no longer appear in unary module

🤖 Generated with [Claude Code](https://claude.ai/code)