### PR TITLE
Add interior padding support to pad op

### DIFF
--- a/tests/configs/shape.py
+++ b/tests/configs/shape.py
@@ -1,3 +1,4 @@
+import jax
 from jax import numpy as jnp
 from jax import random
 
@@ -60,6 +61,13 @@ def make_shape_op_configs():
                 lambda x: jnp.pad(x, ((1, 1), (2, 2))),
                 lambda key: random.normal(key, (3, 3)),
                 # Grad crashes with fatal Metal abort (sliceUpdateDataTensor shape mismatch).
+                differentiable_argnums=(),
+            ),
+            # Pad with interior padding
+            OperationTestConfig(
+                lambda x: jax.lax.pad(x, 0.0, [(1, 1, 1), (0, 0, 2)]),
+                lambda key: random.normal(key, (3, 4)),
+                # Grad crashes with fatal Metal abort (see #59).
                 differentiable_argnums=(),
             ),
         ]


### PR DESCRIPTION
## Summary
- Removes the "interior padding not yet supported" error in `HandlePad`
- Uses stride-based `sliceUpdateDataTensor` to place input elements with gaps — interior padding of N maps to stride N+1
- Adds test using `jax.lax.pad` with interior padding `[(1, 1, 1), (0, 0, 2)]`

Relates to #48.

## Test plan
- [x] New interior padding test passes (value check, jit + eager)
- [x] Existing edge-only padding test still passes
- [x] `ruff check` and `ruff format --check` pass
- [x] Full test suite — no new failures (pre-existing failures on main confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)