### PR TITLE
Add StableHLO algebraic simplification pass

### DIFF
--- a/scripts/setup_deps.sh
+++ b/scripts/setup_deps.sh
@@ -231,11 +231,17 @@ install_stablehlo_headers() {
     cp "$STABLEHLO_DIR/stablehlo/api/"*.h "$PREFIX/include/stablehlo/api/"
     cp "$STABLEHLO_DIR/stablehlo/transforms/"*.h "$PREFIX/include/stablehlo/transforms/"
     cp "$STABLEHLO_DIR/stablehlo/transforms/optimization/"*.h "$PREFIX/include/stablehlo/transforms/optimization/"
-    # Copy generated tablegen headers (only available after a build)
+    # Copy generated tablegen headers (only available after a build).
+    # In cached-install scenarios the build directory may have been cleaned
+    # while the prefix still has headers. Warn if .inc files are missing.
     if [ -d "$STABLEHLO_BUILD_DIR" ]; then
         cp "$STABLEHLO_BUILD_DIR/stablehlo/dialect/"*.inc "$PREFIX/include/stablehlo/dialect/" 2>/dev/null || true
         cp "$STABLEHLO_BUILD_DIR/stablehlo/transforms/"*.inc "$PREFIX/include/stablehlo/transforms/" 2>/dev/null || true
         cp "$STABLEHLO_BUILD_DIR/stablehlo/transforms/optimization/"*.inc "$PREFIX/include/stablehlo/transforms/optimization/" 2>/dev/null || true
+    elif ! compgen -G "$PREFIX/include/stablehlo/dialect/"'*.inc' > /dev/null 2>&1; then
+        echo "WARNING: StableHLO generated headers (*.inc) not found and build"
+        echo "  directory is unavailable. Re-run setup_deps.sh with --force to"
+        echo "  rebuild StableHLO and regenerate the missing headers."
     fi
 }
 

--- a/src/pjrt_plugin/ops/control_flow_ops.mm
+++ b/src/pjrt_plugin/ops/control_flow_ops.mm
@@ -65,14 +65,22 @@ NSArray<MPSGraphTensor*>* EvaluateWhileBody(MPSGraph* graph, mlir::Block& bodyBl
             return bodyArgs;
         }
 
-        // MPS Graph may promote scalar tensors to rank-1 inside while loop bodies,
-        // causing shape mismatches between body outputs and loop-carried types
-        // (e.g., tensor<f32> becomes tensor<1xf32>). Reshape back to match.
-        // This is safe because only the rank changes, not the element count.
+        // MPS Graph may promote scalar () to rank-1 (1,) inside while loop
+        // bodies. Only reshape for that specific case to avoid masking real
+        // shape bugs.
         if (i < bodyArgs.count) {
             NSArray<NSNumber*>* expectedShape = bodyArgs[i].shape;
-            if (expectedShape && ![tensor.shape isEqualToArray:expectedShape]) {
-                tensor = [graph reshapeTensor:tensor withShape:expectedShape name:nil];
+            NSArray<NSNumber*>* actualShape = tensor.shape;
+            if (expectedShape && actualShape && ![actualShape isEqualToArray:expectedShape]) {
+                NSUInteger expectedRank = expectedShape.count;
+                NSUInteger actualRank = actualShape.count;
+                bool scalarToVector =
+                    (expectedRank == 0 && actualRank == 1 && [actualShape[0] isEqualToNumber:@1]);
+                bool vectorToScalar =
+                    (actualRank == 0 && expectedRank == 1 && [expectedShape[0] isEqualToNumber:@1]);
+                if (scalarToVector || vectorToScalar) {
+                    tensor = [graph reshapeTensor:tensor withShape:expectedShape name:nil];
+                }
             }
         }
 

--- a/src/pjrt_plugin/stablehlo_parser.mm
+++ b/src/pjrt_plugin/stablehlo_parser.mm
@@ -5,6 +5,7 @@
 
 #import <Foundation/Foundation.h>
 
+#include <cstdlib>
 #include <unordered_set>
 
 #include "llvm/Support/MemoryBuffer.h"


### PR DESCRIPTION
## Summary

- Run StableHLO's algebraic simplification pass on the IR before execution
- Optimizes patterns like `x*1 -> x`, `x+0 -> x`, `x/x -> 1` that XLA does not simplify before sending to PJRT
- Fix while-loop scalar promotion mismatch in MPS Graph (scalar `()` ↔ rank-1 `(1,)`)
- Fail hard on pass failure with `JAX_MPS_NO_OPTIMIZE=1` escape hatch
- Updates `setup_deps.sh` to install StableHLO transforms headers (including for cached deps)

## Background

Investigation of the [MetalHLO](https://github.com/pedronahum/MetalHLO) project revealed that PJRT backends receive unoptimized StableHLO IR from JAX/XLA. StableHLO provides target-independent optimization passes that we can run before execution.

Currently only the **algebraic simplification** pass is enabled. The **constant folding** pass is excluded due to execution hangs with certain patterns (tracked in #64).

## Test plan

- [x] All existing tests pass (1474 passed, 266 skipped, 34 xfailed)
- [x] Build succeeds with proper header includes
- [x] Pass failure is fatal with clear error message pointing to escape hatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)