### PR TITLE
Support gather with no collapsed slice dims

### DIFF
--- a/src/pjrt_plugin/mlx_executable.mm
+++ b/src/pjrt_plugin/mlx_executable.mm
@@ -927,17 +927,24 @@ bool HandleGather(mlir::Operation* op, ValueMap& values, std::vector<mlx::core::
     auto indexVectorDim = static_cast<int>(dimNumbers.getIndexVectorDim());
     auto operandBatchingDims = dimNumbers.getOperandBatchingDims();
 
-    // Simple case: single index dimension, single collapsed dim
-    // This handles the common pattern: gather(data, indices) -> data[indices]
-    if (startIndexMap.size() == 1 && collapsedSliceDims.size() == 1 &&
-        static_cast<int64_t>(startIndexMap[0]) == static_cast<int64_t>(collapsedSliceDims[0])) {
+    // Simple case: single index dimension, optionally collapsed
+    // This handles patterns like: gather(data, indices) -> data[indices]
+    // When collapsedSliceDims is non-empty, the gathered dim is removed from output.
+    // When collapsedSliceDims is empty, the gathered dim is kept (as a slice dim).
+    if (startIndexMap.size() == 1 &&
+        (collapsedSliceDims.empty() ||
+         (collapsedSliceDims.size() == 1 &&
+          static_cast<int64_t>(startIndexMap[0]) == static_cast<int64_t>(collapsedSliceDims[0])))) {
         int gatherDim = static_cast<int>(startIndexMap[0]);
+        bool collapsed = !collapsedSliceDims.empty();
 
         // Extract the index vector
         auto indices = startIndices;
         if (indexVectorDim < static_cast<int>(startIndices.shape().size())) {
-            // Index vector dim exists - squeeze it if it's size 1
-            if (startIndices.shape(indexVectorDim) == 1) {
+            // Index vector dim exists - squeeze it if it's size 1 and the dim is collapsed
+            // When not collapsed, keep the index vector dim so take_along_axis
+            // produces the right output shape (with the slice dimension).
+            if (collapsed && startIndices.shape(indexVectorDim) == 1) {
                 indices = mlx::core::squeeze(startIndices, {indexVectorDim});
             }
         }

--- a/tests/configs/numpyro.py
+++ b/tests/configs/numpyro.py
@@ -99,21 +99,14 @@ def make_numpyro_op_configs():
                     differentiable_argnums=(1,),
                     name="Bernoulli",
                 ),
-                pytest.param(
-                    NumpyroDistributionTestConfig(
-                        dists.BinomialProbs,
-                        lambda key, bs=batch_shape: random.uniform(
-                            key, bs, minval=0.1, maxval=0.9
-                        ),
-                        10,  # total_count (not differentiable)
-                        differentiable_argnums=(1,),
-                        name="Binomial",
+                NumpyroDistributionTestConfig(
+                    dists.BinomialProbs,
+                    lambda key, bs=batch_shape: random.uniform(
+                        key, bs, minval=0.1, maxval=0.9
                     ),
-                    marks=[
-                        xfail_match(
-                            "Output count mismatch|unsupported gather pattern|Segfault"
-                        )
-                    ],
+                    10,  # total_count (not differentiable)
+                    differentiable_argnums=(1,),
+                    name="Binomial",
                 ),
                 NumpyroDistributionTestConfig(
                     dists.CategoricalProbs,

--- a/tests/configs/slice.py
+++ b/tests/configs/slice.py
@@ -4,7 +4,7 @@ import pytest
 from jax import lax, random
 from jax import numpy as jnp
 
-from .util import OperationTestConfig, xfail_match
+from .util import OperationTestConfig
 
 
 def make_slice_op_configs():
@@ -162,17 +162,24 @@ def make_slice_op_configs():
                 name="multi_index_point_gather",
             ),
             # Batched gather via vmap
-            pytest.param(
-                OperationTestConfig(
-                    lambda x, idx: jax.vmap(
-                        lambda xi, ii: lax.dynamic_index_in_dim(xi, ii, 0, False)
-                    )(x, idx),
-                    lambda key: random.normal(key, (3, 10)),
-                    lambda key: random.randint(key, (3,), 0, 10),
-                    name="batched_single_axis_gather",
-                    grad_xfail="Output count mismatch",
+            OperationTestConfig(
+                lambda x, idx: jax.vmap(
+                    lambda xi, ii: lax.dynamic_index_in_dim(xi, ii, 0, False)
+                )(x, idx),
+                lambda key: random.normal(key, (3, 10)),
+                lambda key: random.randint(key, (3,), 0, 10),
+                name="batched_single_axis_gather",
+                grad_xfail="Output count mismatch",
+            ),
+            # Batched gather via vmap with no collapsed dims (issue #74)
+            OperationTestConfig(
+                lambda x, idx: jax.vmap(lambda state, i: state[i], in_axes=(0, 0))(
+                    x, idx
                 ),
-                marks=[xfail_match("Output count mismatch")],
+                lambda key: random.normal(key, (4, 5)),
+                lambda key: random.randint(key, (4,), 0, 5),
+                name="batched_gather_no_collapse",
+                grad_xfail="Output count mismatch",
             ),
             # Large integer gather tests: verify integers > 2^24 are preserved
             # These test the bitcast workaround for MPS gather operations


### PR DESCRIPTION
## Summary
- Extends `HandleGather` pattern 1 to accept empty `collapsedSliceDims`, fixing batched `vmap` gathers that keep the slice dimension instead of collapsing it
- Removes xfail from `numpyro.Binomial` and `batched_single_axis_gather` value tests (now passing)
- Adds `batched_gather_no_collapse` test case

Fixes #74

## Test plan
- [x] Verified the exact reproducer from #74 outputs `[0 3]` matching CPU
- [x] Full test suite passes (1530 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)