### PR TITLE
Fix metallib not found on other machines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,5 @@ __pycache__/
 build/
 dist/
 playground/
-third_party/
 tickets/
 wheels/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,3 +260,21 @@ install(TARGETS pjrt_plugin_mps
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION lib
 )
+
+# Install MLX metallib alongside the dylib so MLX's colocated search finds it.
+# MLX's current_binary_dir() resolves to the dylib's directory (since MLX is
+# statically linked), and load_default_library() checks for mlx.metallib there.
+find_file(MLX_METALLIB mlx.metallib HINTS ${CMAKE_PREFIX_PATH} PATH_SUFFIXES lib)
+if(MLX_METALLIB)
+    message(STATUS "Found mlx.metallib: ${MLX_METALLIB}")
+    # Copy to build lib dir (for editable installs where dylib is loaded directly)
+    add_custom_command(TARGET pjrt_plugin_mps POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${MLX_METALLIB} $<TARGET_FILE_DIR:pjrt_plugin_mps>/mlx.metallib
+        COMMENT "Copying mlx.metallib alongside pjrt_plugin_mps"
+    )
+    # Install to wheel lib dir (for pip install from wheel)
+    install(FILES ${MLX_METALLIB} DESTINATION lib)
+else()
+    message(WARNING "mlx.metallib not found - Metal GPU kernels will not be available")
+endif()

--- a/third_party/mlx/patches/02-metallib-colocated-only.patch
+++ b/third_party/mlx/patches/02-metallib-colocated-only.patch
@@ -1,0 +1,57 @@
+diff --git a/mlx/backend/metal/device.cpp b/mlx/backend/metal/device.cpp
+index 15824d6..15d4826 100644
+--- a/mlx/backend/metal/device.cpp
++++ b/mlx/backend/metal/device.cpp
+@@ -134,9 +134,9 @@ std::pair<MTL::Library*, NS::Error*> load_swiftpm_library(
+ }
+ 
+ MTL::Library* load_default_library(MTL::Device* device) {
+-  NS::Error* error[5];
++  NS::Error* error[2];
+   MTL::Library* lib;
+-  // First try the colocated mlx.metallib
++  // Try the colocated mlx.metallib (next to the binary/dylib)
+   std::tie(lib, error[0]) = load_colocated_library(device, "mlx");
+   if (lib) {
+     return lib;
+@@ -147,32 +147,16 @@ MTL::Library* load_default_library(MTL::Device* device) {
+     return lib;
+   }
+ 
+-  // Then try default.metallib in a SwiftPM bundle if we have one
+-  std::tie(lib, error[2]) = load_swiftpm_library(device, "default");
+-  if (lib) {
+-    return lib;
+-  }
+-
+-  // Try lo load resources from Framework resources if SwiftPM wrapped as a
+-  // dynamic framework.
+-  std::tie(lib, error[3]) = load_colocated_library(device, "Resources/default");
+-  if (lib) {
+-    return lib;
+-  }
+-
+-  // Finally try default_mtllib_path
+-  std::tie(lib, error[4]) = load_library_from_path(device, default_mtllib_path);
+-  if (!lib) {
+-    std::ostringstream msg;
+-    msg << "Failed to load the default metallib. ";
+-    for (int i = 0; i < 5; i++) {
+-      if (error[i] != nullptr) {
+-        msg << error[i]->localizedDescription()->utf8String() << " ";
+-      }
++  // Only colocated search is supported — no SwiftPM or hardcoded path fallbacks
++  std::ostringstream msg;
++  msg << "Failed to load mlx.metallib (expected next to the jax-mps plugin). ";
++  for (int i = 0; i < 2; i++) {
++    if (error[i] != nullptr) {
++      msg << error[i]->localizedDescription()->utf8String() << " ";
+     }
+-    throw std::runtime_error(msg.str());
+   }
+-  return lib;
++  msg << "Searched: " << current_binary_dir().string();
++  throw std::runtime_error(msg.str());
+ }
+ 
+ MTL::Library* load_library(


### PR DESCRIPTION
## Summary
- Colocate `mlx.metallib` next to `pjrt_plugin_mps.dylib` so MLX's `load_default_library()` finds it via `dladdr`-based colocated search — works for both editable installs and wheels
- Patch MLX to remove SwiftPM and hardcoded `METAL_PATH` fallbacks, preventing local paths from silently masking packaging bugs
- Fix `.gitignore` to stop ignoring `third_party/` so MLX patches are properly tracked

## Test plan
- [x] `uv run python -c 'import jax; print(jax.numpy.ones((3)))'` works
- [x] Removing `mlx.metallib` from build dir produces clear error: "Failed to load mlx.metallib (expected next to the jax-mps plugin). Searched: ..."
- [x] `strings` on the dylib shows no hardcoded filesystem paths
- [x] All pre-commit hooks pass (pytest, pyright, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)