### PR TITLE
Fix while loop with RNG by evaluating loop vars each iteration (#82)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,3 +61,10 @@ Benchmarks are excluded from normal test runs. To run them:
 # Run benchmarks (compares CPU vs MPS performance)
 uv run pytest -m benchmark --benchmark-only -n0
 ```
+
+# Bugs and Issues
+
+When fixing a bug or addressing an issue, use TDD:
+
+1. Create the test to reproduce the issue and verify it fails.
+2. Fix the bug or address the issue and verify the test passes.

--- a/src/pjrt_plugin/mlx_executable.mm
+++ b/src/pjrt_plugin/mlx_executable.mm
@@ -327,6 +327,7 @@ std::optional<std::reference_wrapper<mlx::core::array>> GetValue(ValueMap& value
 // Execution context passed to handlers
 struct ExecContext {
     mlir::ModuleOp module;
+    bool inside_compile = false;  // true when running inside mlx::core::compile()
 };
 
 // Op handler function type
@@ -1743,6 +1744,12 @@ bool HandleWhile(mlir::Operation* op, ValueMap& values, std::vector<mlx::core::a
         return false;
     }
 
+    // While loops require eval() each iteration for the condition and to bound
+    // memory, which is incompatible with mlx::core::compile() tracing.
+    if (ctx.inside_compile) {
+        return false;
+    }
+
     // Get initial values from operands
     std::vector<mlx::core::array> loopVars;
     for (auto operand : op->getOperands()) {
@@ -1757,12 +1764,69 @@ bool HandleWhile(mlir::Operation* op, ValueMap& values, std::vector<mlx::core::a
     auto& condRegion = whileOp.getCond();
     auto& bodyRegion = whileOp.getBody();
 
+    // Try to compile condition and body regions into fused MLX functions so each
+    // iteration is a single compiled dispatch instead of N individual ops.
+    // Falls back to interpreted if compile() itself throws or if the regions
+    // contain ops incompatible with compile tracing (e.g. case/switch need eval).
+    using CompiledFn =
+        std::function<std::vector<mlx::core::array>(const std::vector<mlx::core::array>&)>;
+    CompiledFn compiledCond;
+    CompiledFn compiledBody;
+    bool useCompiled = false;
+    try {
+        compiledCond = mlx::core::compile(
+            [&condRegion, &ctx, &values](
+                const std::vector<mlx::core::array>& inputs) -> std::vector<mlx::core::array> {
+                auto args = inputs;
+                std::vector<mlx::core::array> results;
+                ExecContext compileCtx;
+                compileCtx.module = ctx.module;
+                compileCtx.inside_compile = true;
+                if (!ExecuteRegion(condRegion, args, results, compileCtx, &values)) {
+                    return {};
+                }
+                return results;
+            });
+
+        compiledBody = mlx::core::compile(
+            [&bodyRegion, &ctx, &values](
+                const std::vector<mlx::core::array>& inputs) -> std::vector<mlx::core::array> {
+                auto args = inputs;
+                std::vector<mlx::core::array> results;
+                ExecContext compileCtx;
+                compileCtx.module = ctx.module;
+                compileCtx.inside_compile = true;
+                if (!ExecuteRegion(bodyRegion, args, results, compileCtx, &values)) {
+                    return {};
+                }
+                return results;
+            });
+
+        // Probe: run compiled cond+body once to verify they work
+        auto testCond = compiledCond(loopVars);
+        if (testCond.size() == 1) {
+            auto testBody = compiledBody(loopVars);
+            if (testBody.size() == loopVars.size()) {
+                std::vector<mlx::core::array> toEval;
+                toEval.insert(toEval.end(), testCond.begin(), testCond.end());
+                toEval.insert(toEval.end(), testBody.begin(), testBody.end());
+                mlx::core::eval(toEval);
+                useCompiled = true;
+            }
+        }
+    } catch (...) {
+        useCompiled = false;
+    }
+
     while (true) {
-        // Execute condition region (pass parent values for outer-scope references)
         std::vector<mlx::core::array> condResults;
-        if (!ExecuteRegion(condRegion, loopVars, condResults, ctx, &values)) {
-            MPS_LOG_ERROR("stablehlo.while: failed to execute cond region\n");
-            return false;
+        if (useCompiled) {
+            condResults = compiledCond(loopVars);
+        } else {
+            if (!ExecuteRegion(condRegion, loopVars, condResults, ctx, &values)) {
+                MPS_LOG_ERROR("stablehlo.while: failed to execute cond region\n");
+                return false;
+            }
         }
 
         if (condResults.size() != 1) {
@@ -1771,25 +1835,31 @@ bool HandleWhile(mlir::Operation* op, ValueMap& values, std::vector<mlx::core::a
             return false;
         }
 
-        // Evaluate and check condition
-        mlx::core::eval(condResults[0]);
+        // Evaluate condition (and loop vars from previous iteration to bound memory).
+        // Combining into a single eval() call minimizes GPU sync round-trips.
+        loopVars.push_back(condResults[0]);
+        mlx::core::eval(loopVars);
+        auto condVal = std::move(loopVars.back());
+        loopVars.pop_back();
 
-        // Verify condition is a scalar boolean
-        if (condResults[0].size() != 1) {
+        if (condVal.size() != 1) {
             MPS_LOG_ERROR("stablehlo.while: condition must be a scalar, got size %zu\n",
-                          condResults[0].size());
+                          condVal.size());
             return false;
         }
 
-        if (!condResults[0].item<bool>()) {
+        if (!condVal.item<bool>()) {
             break;
         }
 
-        // Execute body region (pass parent values for outer-scope references)
         std::vector<mlx::core::array> bodyResults;
-        if (!ExecuteRegion(bodyRegion, loopVars, bodyResults, ctx, &values)) {
-            MPS_LOG_ERROR("stablehlo.while: failed to execute body region\n");
-            return false;
+        if (useCompiled) {
+            bodyResults = compiledBody(loopVars);
+        } else {
+            if (!ExecuteRegion(bodyRegion, loopVars, bodyResults, ctx, &values)) {
+                MPS_LOG_ERROR("stablehlo.while: failed to execute body region\n");
+                return false;
+            }
         }
 
         if (bodyResults.size() != loopVars.size()) {
@@ -1798,7 +1868,7 @@ bool HandleWhile(mlir::Operation* op, ValueMap& values, std::vector<mlx::core::a
             return false;
         }
 
-        // Update loop variables
+        // Update loop variables (evaluated at start of next iteration)
         loopVars = std::move(bodyResults);
     }
 
@@ -4159,6 +4229,7 @@ MlxExecuteResult MlxExecutable::Execute(const std::vector<MlxBuffer*>& inputs) {
             std::vector<mlx::core::array> outs;
             ExecContext local_ctx;
             local_ctx.module = *parsed_module_.module;
+            local_ctx.inside_compile = true;
             if (!ExecuteFunction(parsed_module_.entry_func, inputs, outs, local_ctx)) {
                 return {};
             }

--- a/tests/configs/control_flow.py
+++ b/tests/configs/control_flow.py
@@ -1,3 +1,4 @@
+import jax
 import numpy
 from jax import lax, random
 from jax import numpy as jnp
@@ -380,5 +381,49 @@ def make_control_flow_op_configs():
                 numpy.float32(1.0),
                 differentiable_argnums=(),  # while_loop doesn't support reverse-mode AD
                 name="lax.while_loop.with_switch",
+            ),
+            # ==================== while + rng (issue #82) ====================
+            # fori_loop with rng split + randint accumulation
+            OperationTestConfig(
+                lambda key: lax.fori_loop(
+                    0,
+                    1000,
+                    lambda _, carry: (
+                        jax.random.split(carry[0])[0],
+                        carry[1]
+                        + jax.random.randint(
+                            jax.random.split(carry[0])[1],
+                            shape=(),
+                            minval=0,
+                            maxval=2,
+                        ),
+                    ),
+                    (key, jnp.int32(0)),
+                )[1],
+                lambda key: key,
+                name="lax.fori_loop.rng_accumulate",
+            ),
+            # fori_loop with rng split + scatter update
+            OperationTestConfig(
+                lambda key: lax.fori_loop(
+                    0,
+                    1000,
+                    lambda _, carry: (
+                        jax.random.split(carry[0])[0],
+                        carry[1]
+                        .at[
+                            jax.random.randint(
+                                jax.random.split(carry[0])[1],
+                                shape=(),
+                                minval=0,
+                                maxval=2,
+                            )
+                        ]
+                        .set(1),
+                    ),
+                    (key, jnp.zeros(2, dtype=jnp.int8)),
+                )[1],
+                lambda key: key,
+                name="lax.fori_loop.rng_scatter",
             ),
         ]


### PR DESCRIPTION
## Summary

- Fix `stablehlo.while` failing with `Output count mismatch: expected 1, got 0` when loop bodies contain RNG operations (e.g. `jax.random.split` + `jax.random.randint`)
- Add `mlx::core::eval(loopVars)` each iteration to prevent unbounded lazy graph growth
- Compile condition and body regions into fused MLX functions for ~5x speedup
- Skip while loop during `mlx::core::compile()` tracing (incompatible with eval), falling back gracefully to direct execution
- Add `ExecContext::inside_compile` flag to distinguish compile tracing from normal execution

## Test plan

- [x] Added `lax.fori_loop.rng_accumulate` test (1000 iterations, RNG split + randint)
- [x] Added `lax.fori_loop.rng_scatter` test (1000 iterations, RNG split + scatter update)
- [x] Verified both tests fail on unfixed code with exact error from issue
- [x] Verified both MWEs from issue produce correct results
- [x] All 32 existing while/fori loop tests pass
- [x] Full test suite passes

Closes #82
Filed #83 for remaining while loop performance gap vs CPU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)