### PR TITLE
Fix #102: support multi-batch gather/scatter with no collapsed dims

### DIFF
--- a/src/pjrt_plugin/mlx_executable.cc
+++ b/src/pjrt_plugin/mlx_executable.cc
@@ -4105,6 +4105,15 @@ bool HandleScatter(mlir::Operation* op, ValueMap& values, std::vector<mlx::core:
                     std::vector<int> squeezeDims;
                     for (int d = 0; d < updateVal.ndim(); ++d) {
                         if (windowDimSet.count(d) == 0) {
+                            if (updateVal.shape(d) != 1) {
+                                MPS_LOG_ERROR(
+                                    "stablehlo.scatter: non-window dim %d has size %d (expected 1) "
+                                    "in single-update path\n",
+                                    d, updateVal.shape(d));
+                                throw std::runtime_error(
+                                    "stablehlo.scatter: non-window dim has size != 1 in "
+                                    "single-update path");
+                            }
                             squeezeDims.push_back(d);
                         }
                     }

--- a/tests/configs/slice.py
+++ b/tests/configs/slice.py
@@ -365,9 +365,9 @@ def make_slice_op_configs():
                 lambda key: random.normal(key, (2, 3, 3)),
                 name="multi_dim_gather_no_collapse",
             ),
-            # Multi-dim gather with no collapsed dims and multiple batch positions.
-            # Same as multi_dim_gather_no_collapse but with 3 batch positions
-            # instead of 1, triggering the multi-batch code path (issue #102).
+            # Similar to multi_dim_gather_no_collapse but with 3 batch positions
+            # and offset_dims shifted to (1, 2, 3) so the leading dimension is
+            # treated as batch, triggering the multi-batch code path (issue #102).
             OperationTestConfig(
                 lambda x: lax.gather(
                     x,


### PR DESCRIPTION
## Summary

Fixes #102

- The gather handler rejected multi-dim gathers with no collapsed slice dims when `start_indices` had multiple batch positions (non-index-vector dims > 1), producing the error `"multi-dim no-collapse path requires single slice position"`
- Replaced the single-position `mlx::core::slice` path with `mlx::core::gather` which natively handles batched multi-axis slicing
- Fixed the corresponding scatter handler (used in gradients) to loop over batch positions for `slice_update` operations

## Test plan

- [x] New test `multi_dim_gather_no_collapse_batched` reproduces the original issue (fails without fix)
- [x] New test passes with fix applied (value + grad, jit + eager)
- [x] Full test suite passes (1821 passed, 196 skipped, 112 xfailed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)