### PR TITLE
Fix numerical correctness issues in arithmetic, comparison, and sort ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jax-mps
 
-[![GitHub Action Badge](https://github.com/tillahoffmann/jax-mps/actions/workflows/build.yml/badge.svg)](https://github.com/tillahoffmann/jax-mps/actions/workflows/build.yml) [![PyPI](https://img.shields.io/pypi/v/jax-mps)](https://pypi.org/project/jax-mps/) ![JAX tests](https://img.shields.io/badge/JAX_tests-91.7%25_passing-yellow)[^1]
+[![GitHub Action Badge](https://github.com/tillahoffmann/jax-mps/actions/workflows/build.yml/badge.svg)](https://github.com/tillahoffmann/jax-mps/actions/workflows/build.yml) [![PyPI](https://img.shields.io/pypi/v/jax-mps)](https://pypi.org/project/jax-mps/) ![JAX tests](https://img.shields.io/badge/JAX_tests-91.5%25_passing-yellow)[^1]
 
 A JAX backend for Apple Silicon using [MLX](https://github.com/ml-explore/mlx), enabling GPU-accelerated JAX computations on Mac.
 

--- a/src/pjrt_plugin/ops/arithmetic.cc
+++ b/src/pjrt_plugin/ops/arithmetic.cc
@@ -237,6 +237,9 @@ bool HandleCompare(mlir::Operation* op, ValueMap& values, std::vector<mlx::core:
     mlx::core::array a = *lhs;
     mlx::core::array b = *rhs;
     if (isTotalOrder && mlx::core::issubdtype(lhs->dtype(), mlx::core::floating)) {
+        // Promote to float32 for the bit-trick key mapping. This may canonicalize
+        // NaN payloads from float16/bfloat16, but JAX does not rely on distinguishing
+        // NaN payloads in practice (all NaNs compare as equal in searchsorted etc.).
         if (lhs->dtype() != mlx::core::float32) {
             a = mlx::core::astype(a, mlx::core::float32);
             b = mlx::core::astype(b, mlx::core::float32);

--- a/src/pjrt_plugin/ops/arithmetic.cc
+++ b/src/pjrt_plugin/ops/arithmetic.cc
@@ -199,6 +199,22 @@ bool HandleSelect(mlir::Operation* op, ValueMap& values, std::vector<mlx::core::
     return true;
 }
 
+// Convert float to a sortable integer key for IEEE 754 total ordering.
+// Maps floats to signed integers such that integer comparison gives total order:
+// -NaN < -inf < -finite < -0 < +0 < +finite < +inf < +NaN
+mlx::core::array FloatToTotalOrderKey(const mlx::core::array& x) {
+    auto bits = mlx::core::view(x, mlx::core::int32);
+    // For positive floats (sign bit 0), the int32 representation already has
+    // the correct order. For negative floats (sign bit 1), flip all value bits
+    // and subtract 1 to reverse their order.
+    auto zero = mlx::core::array(0, mlx::core::int32);
+    auto is_neg = mlx::core::less(bits, zero);
+    auto flipped = mlx::core::subtract(
+        mlx::core::bitwise_xor(bits, mlx::core::array(0x7FFFFFFF, mlx::core::int32)),
+        mlx::core::array(1, mlx::core::int32));
+    return mlx::core::where(is_neg, flipped, bits);
+}
+
 // Handler for stablehlo.compare
 bool HandleCompare(mlir::Operation* op, ValueMap& values, std::vector<mlx::core::array>& outputs,
                    ExecContext& ctx) {
@@ -212,27 +228,43 @@ bool HandleCompare(mlir::Operation* op, ValueMap& values, std::vector<mlx::core:
         return false;
 
     auto direction = compareOp.getComparisonDirection();
-    std::optional<mlx::core::array> result;
+    auto compareType = compareOp.getCompareType();
 
+    // For TOTALORDER comparisons on floats, use IEEE 754 total ordering
+    // where NaN has a defined position: -NaN < -inf < ... < +inf < +NaN.
+    bool isTotalOrder =
+        compareType.has_value() && *compareType == mlir::stablehlo::ComparisonType::TOTALORDER;
+    mlx::core::array a = *lhs;
+    mlx::core::array b = *rhs;
+    if (isTotalOrder && mlx::core::issubdtype(lhs->dtype(), mlx::core::floating)) {
+        if (lhs->dtype() != mlx::core::float32) {
+            a = mlx::core::astype(a, mlx::core::float32);
+            b = mlx::core::astype(b, mlx::core::float32);
+        }
+        a = FloatToTotalOrderKey(a);
+        b = FloatToTotalOrderKey(b);
+    }
+
+    std::optional<mlx::core::array> result;
     using Dir = mlir::stablehlo::ComparisonDirection;
     switch (direction) {
         case Dir::EQ:
-            result = mlx::core::equal(*lhs, *rhs);
+            result = mlx::core::equal(a, b);
             break;
         case Dir::NE:
-            result = mlx::core::not_equal(*lhs, *rhs);
+            result = mlx::core::not_equal(a, b);
             break;
         case Dir::LT:
-            result = mlx::core::less(*lhs, *rhs);
+            result = mlx::core::less(a, b);
             break;
         case Dir::LE:
-            result = mlx::core::less_equal(*lhs, *rhs);
+            result = mlx::core::less_equal(a, b);
             break;
         case Dir::GT:
-            result = mlx::core::greater(*lhs, *rhs);
+            result = mlx::core::greater(a, b);
             break;
         case Dir::GE:
-            result = mlx::core::greater_equal(*lhs, *rhs);
+            result = mlx::core::greater_equal(a, b);
             break;
         default:
             MPS_LOG_ERROR("stablehlo.compare: unsupported comparison direction\n");
@@ -420,6 +452,47 @@ bool HandleReducePrecision(mlir::Operation* op, ValueMap& values,
     return true;
 }
 
+// Handler for stablehlo.divide
+// MLX divide promotes integer operands to float. StableHLO divide on integers
+// must be integer division (truncation toward zero), so use floor_divide for
+// integer types (MLX floor_divide on integers is C-style truncation division).
+bool HandleDivide(mlir::Operation* op, ValueMap& values, std::vector<mlx::core::array>& outputs,
+                  ExecContext& ctx) {
+    auto* lhs = RequireValue(values, op->getOperand(0), "stablehlo.divide");
+    auto* rhs = RequireValue(values, op->getOperand(1), "stablehlo.divide");
+    if (!lhs || !rhs)
+        return false;
+    auto dtype = lhs->dtype();
+    bool isInteger =
+        (dtype == mlx::core::int8 || dtype == mlx::core::int16 || dtype == mlx::core::int32 ||
+         dtype == mlx::core::int64 || dtype == mlx::core::uint8 || dtype == mlx::core::uint16 ||
+         dtype == mlx::core::uint32 || dtype == mlx::core::uint64);
+    if (isInteger) {
+        values.emplace(ToKey(op->getResult(0)), mlx::core::floor_divide(*lhs, *rhs));
+    } else {
+        values.emplace(ToKey(op->getResult(0)), mlx::core::divide(*lhs, *rhs));
+    }
+    return true;
+}
+
+// Handler for stablehlo.sign
+// MLX sign returns 0 for NaN, but StableHLO requires NaN propagation.
+bool HandleSign(mlir::Operation* op, ValueMap& values, std::vector<mlx::core::array>& outputs,
+                ExecContext& ctx) {
+    auto* x = RequireValue(values, op->getOperand(0), "stablehlo.sign");
+    if (!x)
+        return false;
+    auto result = mlx::core::sign(*x);
+    auto dtype = x->dtype();
+    bool isFloat = (dtype == mlx::core::float16 || dtype == mlx::core::bfloat16 ||
+                    dtype == mlx::core::float32 || dtype == mlx::core::complex64);
+    if (isFloat) {
+        result = mlx::core::where(mlx::core::isnan(*x), *x, result);
+    }
+    values.emplace(ToKey(op->getResult(0)), std::move(result));
+    return true;
+}
+
 }  // namespace
 
 void RegisterArithmeticHandlers(std::unordered_map<std::string, OpHandler>& handlers) {
@@ -438,7 +511,7 @@ void RegisterArithmeticHandlers(std::unordered_map<std::string, OpHandler>& hand
     handlers.insert({"stablehlo.cosine", MakeUnaryHandler("stablehlo.cosine", mlx::core::cos)});
     handlers.insert({"stablehlo.tanh", MakeUnaryHandler("stablehlo.tanh", mlx::core::tanh)});
     handlers.insert({"stablehlo.tan", MakeUnaryHandler("stablehlo.tan", mlx::core::tan)});
-    handlers.insert({"stablehlo.sign", MakeUnaryHandler("stablehlo.sign", mlx::core::sign)});
+    handlers.insert({"stablehlo.sign", HandleSign});
     handlers.insert(
         {"stablehlo.log_plus_one", MakeUnaryHandler("stablehlo.log_plus_one", mlx::core::log1p)});
     handlers.insert({"stablehlo.round_nearest_even",
@@ -456,7 +529,7 @@ void RegisterArithmeticHandlers(std::unordered_map<std::string, OpHandler>& hand
         {"stablehlo.subtract", MakeBinaryHandler("stablehlo.subtract", mlx::core::subtract)});
     handlers.insert(
         {"stablehlo.multiply", MakeBinaryHandler("stablehlo.multiply", mlx::core::multiply)});
-    handlers.insert({"stablehlo.divide", MakeBinaryHandler("stablehlo.divide", mlx::core::divide)});
+    handlers.insert({"stablehlo.divide", HandleDivide});
     handlers.insert(
         {"stablehlo.maximum", MakeBinaryHandler("stablehlo.maximum", mlx::core::maximum)});
     handlers.insert(

--- a/src/pjrt_plugin/ops/linalg.cc
+++ b/src/pjrt_plugin/ops/linalg.cc
@@ -112,9 +112,11 @@ bool HandleDotGeneral(mlir::Operation* op, ValueMap& values, std::vector<mlx::co
     auto resultDtype = GetResultDtype(op, "stablehlo.dot_general");
     if (!resultDtype)
         return false;
-    bool needsCast = !mlx::core::issubdtype(lhs->dtype(), mlx::core::inexact);
-    mlx::core::array lhsVal = needsCast ? mlx::core::astype(*lhs, mlx::core::float32) : *lhs;
-    mlx::core::array rhsVal = needsCast ? mlx::core::astype(*rhs, mlx::core::float32) : *rhs;
+    bool lhsNeedsCast = !mlx::core::issubdtype(lhs->dtype(), mlx::core::inexact);
+    bool rhsNeedsCast = !mlx::core::issubdtype(rhs->dtype(), mlx::core::inexact);
+    bool needsCast = lhsNeedsCast || rhsNeedsCast;
+    mlx::core::array lhsVal = lhsNeedsCast ? mlx::core::astype(*lhs, mlx::core::float32) : *lhs;
+    mlx::core::array rhsVal = rhsNeedsCast ? mlx::core::astype(*rhs, mlx::core::float32) : *rhs;
 
     // Try einsum path if enabled
     if (UseEinsumForDotGeneral()) {

--- a/src/pjrt_plugin/ops/reduction.cc
+++ b/src/pjrt_plugin/ops/reduction.cc
@@ -18,23 +18,33 @@ ReduceType DetectReduceType(mlir::Region& body) {
     if (body.empty())
         return ReduceType::Unknown;
 
+    // Only match bodies with exactly one "real" op (plus the return).
+    // Multi-op bodies (e.g., logaddexp: max + sub + exp + log1p + add + select)
+    // must not be misidentified as a simple reduction.
     auto& block = body.front();
+    int realOpCount = 0;
+    ReduceType detected = ReduceType::Unknown;
     for (auto& op : block.getOperations()) {
         auto opName = op.getName().getStringRef();
+        if (opName == "stablehlo.return")
+            continue;
+        ++realOpCount;
+        if (realOpCount > 1)
+            return ReduceType::Unknown;
         if (opName == "stablehlo.add")
-            return ReduceType::Sum;
-        if (opName == "stablehlo.maximum")
-            return ReduceType::Max;
-        if (opName == "stablehlo.minimum")
-            return ReduceType::Min;
-        if (opName == "stablehlo.multiply")
-            return ReduceType::Prod;
-        if (opName == "stablehlo.and")
-            return ReduceType::And;
-        if (opName == "stablehlo.or")
-            return ReduceType::Or;
+            detected = ReduceType::Sum;
+        else if (opName == "stablehlo.maximum")
+            detected = ReduceType::Max;
+        else if (opName == "stablehlo.minimum")
+            detected = ReduceType::Min;
+        else if (opName == "stablehlo.multiply")
+            detected = ReduceType::Prod;
+        else if (opName == "stablehlo.and")
+            detected = ReduceType::And;
+        else if (opName == "stablehlo.or")
+            detected = ReduceType::Or;
     }
-    return ReduceType::Unknown;
+    return detected;
 }
 
 // Detect argmax/argmin pattern in a 2-input reduce body.

--- a/src/pjrt_plugin/ops/shape.cc
+++ b/src/pjrt_plugin/ops/shape.cc
@@ -116,7 +116,32 @@ bool HandleConvert(mlir::Operation* op, ValueMap& values, std::vector<mlx::core:
     if (!targetDtype)
         return false;
 
-    values.emplace(ToKey(op->getResult(0)), mlx::core::astype(*input, *targetDtype));
+    auto result = *input;
+    auto srcDtype = input->dtype();
+
+    // Workaround for https://github.com/ml-explore/mlx/issues/3338
+    // MLX compile() incorrectly fuses chained casts when converting from an unsigned
+    // integer type to a signed type followed by float promotion (e.g.,
+    // uint16->int32->float32 gets fused into a single kernel that misreads bytes).
+    // Work around by widening to the unsigned type of the target width, then using
+    // view() to reinterpret bits as signed. view() acts as a compile barrier (it is
+    // not fused with subsequent astype) and has zero runtime cost.
+    bool srcUnsigned = mlx::core::issubdtype(srcDtype, mlx::core::unsignedinteger);
+    bool tgtSigned = mlx::core::issubdtype(*targetDtype, mlx::core::signedinteger);
+    if (srcUnsigned && tgtSigned) {
+        mlx::core::Dtype targetUnsigned = mlx::core::uint32;
+        if (*targetDtype == mlx::core::int8)
+            targetUnsigned = mlx::core::uint8;
+        else if (*targetDtype == mlx::core::int16)
+            targetUnsigned = mlx::core::uint16;
+        else if (*targetDtype == mlx::core::int64)
+            targetUnsigned = mlx::core::uint64;
+        result = mlx::core::astype(result, targetUnsigned);
+        values.emplace(ToKey(op->getResult(0)), mlx::core::view(result, *targetDtype));
+        return true;
+    }
+
+    values.emplace(ToKey(op->getResult(0)), mlx::core::astype(result, *targetDtype));
     return true;
 }
 

--- a/src/pjrt_plugin/ops/sort_fft_complex.cc
+++ b/src/pjrt_plugin/ops/sort_fft_complex.cc
@@ -23,32 +23,20 @@ mlx::core::array ReverseAxisImpl(const mlx::core::array& a, int axis) {
 }
 
 // Compute top-k values and indices along the last axis.
-// For float types, uses negation + ascending argsort + take-first-k to preserve stable
-// tie ordering. For integer types, negation can overflow (e.g., INT_MIN), so we fall
-// back to ascending argsort + take-last-k + reverse (correct values, less stable ties).
+// Uses negation + ascending argsort + take-first-k to get descending order while
+// preserving stable tie ordering (equal values keep lowest-index-first).
+// Note: integer negation overflows for INT_MIN/UINT types, but this only affects
+// tie-breaking order for those extreme values, not correctness of the top-k values.
 std::pair<mlx::core::array, mlx::core::array> TopKImplFn(const mlx::core::array& input, int k) {
     int axis = static_cast<int>(input.ndim()) - 1;
+    auto negated = mlx::core::negative(input);
+    auto allIndices = mlx::core::argsort(negated, axis);
 
-    if (mlx::core::issubdtype(input.dtype(), mlx::core::inexact)) {
-        // Float path: negate to convert descending to ascending, preserving tie order.
-        auto negated = mlx::core::negative(input);
-        auto allIndices = mlx::core::argsort(negated, axis);
-        mlx::core::Shape starts(allIndices.ndim(), 0);
-        mlx::core::Shape stops(allIndices.shape().begin(), allIndices.shape().end());
-        stops[axis] = k;
-        auto indices = mlx::core::slice(allIndices, starts, stops);
-        auto topValues = mlx::core::take_along_axis(input, indices, axis);
-        return {topValues, mlx::core::astype(indices, mlx::core::int32)};
-    }
-
-    // Integer path: ascending argsort + take-last-k + reverse (safe for all int types).
-    auto allIndices = mlx::core::argsort(input, axis);
-    int dimSize = input.shape(axis);
     mlx::core::Shape starts(allIndices.ndim(), 0);
     mlx::core::Shape stops(allIndices.shape().begin(), allIndices.shape().end());
-    starts[axis] = dimSize - k;
-    auto topAsc = mlx::core::slice(allIndices, starts, stops);
-    auto indices = ReverseAxisImpl(topAsc, axis);
+    stops[axis] = k;
+    auto indices = mlx::core::slice(allIndices, starts, stops);
+
     auto topValues = mlx::core::take_along_axis(input, indices, axis);
     return {topValues, mlx::core::astype(indices, mlx::core::int32)};
 }

--- a/src/pjrt_plugin/ops/sort_fft_complex.cc
+++ b/src/pjrt_plugin/ops/sort_fft_complex.cc
@@ -23,20 +23,20 @@ mlx::core::array ReverseAxisImpl(const mlx::core::array& a, int axis) {
 }
 
 // Compute top-k values and indices along the last axis.
-// Uses ascending argsort + take-from-end + reverse (no negation, safe for all dtypes).
+// Uses negation + ascending argsort + take-first-k to preserve stable tie ordering.
+// The previous approach (ascending argsort + take-last-k + reverse) broke tie ordering
+// because the reversal flips the order of equal elements.
 std::pair<mlx::core::array, mlx::core::array> TopKImplFn(const mlx::core::array& input, int k) {
     int axis = static_cast<int>(input.ndim()) - 1;
-    auto allIndices = mlx::core::argsort(input, axis);
+    auto negated = mlx::core::negative(input);
+    auto allIndices = mlx::core::argsort(negated, axis);
 
-    // Take the last k indices (largest values in ascending order)
-    int dimSize = input.shape(axis);
+    // Take the first k indices (largest original values, stable tie order preserved)
     mlx::core::Shape starts(allIndices.ndim(), 0);
     mlx::core::Shape stops(allIndices.shape().begin(), allIndices.shape().end());
-    starts[axis] = dimSize - k;
-    auto topAsc = mlx::core::slice(allIndices, starts, stops);
+    stops[axis] = k;
+    auto indices = mlx::core::slice(allIndices, starts, stops);
 
-    // Reverse to get descending order
-    auto indices = ReverseAxisImpl(topAsc, axis);
     auto topValues = mlx::core::take_along_axis(input, indices, axis);
     return {topValues, mlx::core::astype(indices, mlx::core::int32)};
 }

--- a/src/pjrt_plugin/ops/sort_fft_complex.cc
+++ b/src/pjrt_plugin/ops/sort_fft_complex.cc
@@ -23,20 +23,32 @@ mlx::core::array ReverseAxisImpl(const mlx::core::array& a, int axis) {
 }
 
 // Compute top-k values and indices along the last axis.
-// Uses negation + ascending argsort + take-first-k to preserve stable tie ordering.
-// The previous approach (ascending argsort + take-last-k + reverse) broke tie ordering
-// because the reversal flips the order of equal elements.
+// For float types, uses negation + ascending argsort + take-first-k to preserve stable
+// tie ordering. For integer types, negation can overflow (e.g., INT_MIN), so we fall
+// back to ascending argsort + take-last-k + reverse (correct values, less stable ties).
 std::pair<mlx::core::array, mlx::core::array> TopKImplFn(const mlx::core::array& input, int k) {
     int axis = static_cast<int>(input.ndim()) - 1;
-    auto negated = mlx::core::negative(input);
-    auto allIndices = mlx::core::argsort(negated, axis);
 
-    // Take the first k indices (largest original values, stable tie order preserved)
+    if (mlx::core::issubdtype(input.dtype(), mlx::core::inexact)) {
+        // Float path: negate to convert descending to ascending, preserving tie order.
+        auto negated = mlx::core::negative(input);
+        auto allIndices = mlx::core::argsort(negated, axis);
+        mlx::core::Shape starts(allIndices.ndim(), 0);
+        mlx::core::Shape stops(allIndices.shape().begin(), allIndices.shape().end());
+        stops[axis] = k;
+        auto indices = mlx::core::slice(allIndices, starts, stops);
+        auto topValues = mlx::core::take_along_axis(input, indices, axis);
+        return {topValues, mlx::core::astype(indices, mlx::core::int32)};
+    }
+
+    // Integer path: ascending argsort + take-last-k + reverse (safe for all int types).
+    auto allIndices = mlx::core::argsort(input, axis);
+    int dimSize = input.shape(axis);
     mlx::core::Shape starts(allIndices.ndim(), 0);
     mlx::core::Shape stops(allIndices.shape().begin(), allIndices.shape().end());
-    stops[axis] = k;
-    auto indices = mlx::core::slice(allIndices, starts, stops);
-
+    starts[axis] = dimSize - k;
+    auto topAsc = mlx::core::slice(allIndices, starts, stops);
+    auto indices = ReverseAxisImpl(topAsc, axis);
     auto topValues = mlx::core::take_along_axis(input, indices, axis);
     return {topValues, mlx::core::astype(indices, mlx::core::int32)};
 }

--- a/src/pjrt_plugin/ops/sort_fft_complex.cc
+++ b/src/pjrt_plugin/ops/sort_fft_complex.cc
@@ -22,15 +22,26 @@ mlx::core::array ReverseAxisImpl(const mlx::core::array& a, int axis) {
     return mlx::core::take(a, fwd, axis);
 }
 
+// Build a descending sort key: ascending sort of the key gives descending order
+// of the original values, preserving stable tie ordering.
+mlx::core::array DescendingKey(const mlx::core::array& input) {
+    auto dtype = input.dtype();
+    if (mlx::core::issubdtype(dtype, mlx::core::inexact)) {
+        // Float/complex: negate (safe, no overflow issues).
+        return mlx::core::negative(input);
+    }
+    // Integer (signed or unsigned): bitwise NOT reverses order without overflow.
+    // Unsigned: NOT(0)=MAX, NOT(MAX)=0. Signed: NOT(MIN)=MAX, NOT(MAX)=MIN.
+    return mlx::core::bitwise_xor(input, mlx::core::full(input.shape(), -1, dtype));
+}
+
 // Compute top-k values and indices along the last axis.
-// Uses negation + ascending argsort + take-first-k to get descending order while
-// preserving stable tie ordering (equal values keep lowest-index-first).
-// Note: integer negation overflows for INT_MIN/UINT types, but this only affects
-// tie-breaking order for those extreme values, not correctness of the top-k values.
+// Uses a descending sort key + ascending argsort + take-first-k to preserve stable
+// tie ordering (equal values keep lowest-index-first).
 std::pair<mlx::core::array, mlx::core::array> TopKImplFn(const mlx::core::array& input, int k) {
     int axis = static_cast<int>(input.ndim()) - 1;
-    auto negated = mlx::core::negative(input);
-    auto allIndices = mlx::core::argsort(negated, axis);
+    auto key = DescendingKey(input);
+    auto allIndices = mlx::core::argsort(key, axis);
 
     mlx::core::Shape starts(allIndices.ndim(), 0);
     mlx::core::Shape stops(allIndices.shape().begin(), allIndices.shape().end());

--- a/src/pjrt_plugin/ops/sort_fft_complex.cc
+++ b/src/pjrt_plugin/ops/sort_fft_complex.cc
@@ -32,7 +32,7 @@ mlx::core::array DescendingKey(const mlx::core::array& input) {
     }
     // Integer (signed or unsigned): bitwise NOT reverses order without overflow.
     // Unsigned: NOT(0)=MAX, NOT(MAX)=0. Signed: NOT(MIN)=MAX, NOT(MAX)=MIN.
-    return mlx::core::bitwise_xor(input, mlx::core::full(input.shape(), -1, dtype));
+    return mlx::core::bitwise_xor(input, mlx::core::full({}, -1, dtype));
 }
 
 // Compute top-k values and indices along the last axis.

--- a/tests/configs/binary.py
+++ b/tests/configs/binary.py
@@ -283,4 +283,21 @@ def make_binary_op_configs():
                 differentiable_argnums=(),
                 name="lax.shift_right_arithmetic-negative-shift-count",
             ),
+            # Integer division: truncation toward zero (not float promotion)
+            OperationTestConfig(
+                lax.div,
+                numpy.array([7, -7, 7, -7, 0, 100], dtype=numpy.int32),
+                numpy.array([2, 2, -2, -2, 3, 7], dtype=numpy.int32),
+                differentiable_argnums=(),
+                name="lax.div-integer-truncation",
+            ),
+            # Mixed unsigned/signed tensordot (exercises unsigned->signed convert
+            # workaround for ml-explore/mlx#3338)
+            OperationTestConfig(
+                lambda a, b: jnp.tensordot(a, b, axes=0),
+                numpy.array([1, 2, 3], dtype=numpy.int8),
+                numpy.array([10, 20, 30], dtype=numpy.uint16),
+                differentiable_argnums=(),
+                name="jnp.tensordot-mixed-unsigned-signed",
+            ),
         ]

--- a/tests/configs/sort.py
+++ b/tests/configs/sort.py
@@ -384,4 +384,33 @@ def make_sort_op_configs():
             )
         )
 
+        # top_k with ties: test stable tie ordering (negate approach)
+        configs.append(
+            OperationTestConfig(
+                lambda x: lax.top_k(x, 3),
+                jnp.array([3.0, 1.0, 3.0, 2.0, 3.0]),
+                name="lax.top_k.ties",
+            )
+        )
+
+        # top_k with integer input (uses reverse path, not negate)
+        configs.append(
+            OperationTestConfig(
+                lambda x: lax.top_k(x, 3),
+                jnp.array([5, 3, 8, 1, 7], dtype=jnp.int32),
+                differentiable_argnums=(),
+                name="lax.top_k.int32",
+            )
+        )
+
+        # searchsorted with NaN (exercises TOTALORDER comparison)
+        configs.append(
+            OperationTestConfig(
+                lambda x: jnp.searchsorted(x, x),
+                jnp.array([-jnp.inf, -1.0, 0.0, 1.0, jnp.inf, jnp.nan]),
+                differentiable_argnums=(),
+                name="jnp.searchsorted.nan",
+            )
+        )
+
         return configs

--- a/tests/configs/sort.py
+++ b/tests/configs/sort.py
@@ -393,7 +393,7 @@ def make_sort_op_configs():
             )
         )
 
-        # top_k with integer input (exercises widen+negate path)
+        # top_k with integer input (exercises bitwise-NOT descending key)
         configs.append(
             OperationTestConfig(
                 lambda x: lax.top_k(x, 3),

--- a/tests/configs/sort.py
+++ b/tests/configs/sort.py
@@ -393,7 +393,7 @@ def make_sort_op_configs():
             )
         )
 
-        # top_k with integer input (uses reverse path, not negate)
+        # top_k with integer input (exercises widen+negate path)
         configs.append(
             OperationTestConfig(
                 lambda x: lax.top_k(x, 3),

--- a/tests/configs/unary.py
+++ b/tests/configs/unary.py
@@ -244,4 +244,12 @@ def make_unary_op_configs():
             differentiable_argnums=(),
             name="clz-int32",
         ),
+        # sign(NaN) must propagate NaN, not return 0
+        OperationTestConfig(
+            jnp.sign,
+            numpy.array(
+                [1.0, -1.0, 0.0, float("nan"), float("-inf")], dtype=numpy.float32
+            ),
+            name="sign-nan-propagation",
+        ),
     ]


### PR DESCRIPTION
## Summary

Fixes several classes of numerical correctness bugs, recovering ~315 upstream JAX tests (from 90.4% to 91.5% pass rate after the JAX 0.9.1→0.9.2 upgrade):

- **Integer division**: `stablehlo.divide` on integer types now uses `mlx::core::floor_divide` instead of `mlx::core::divide` (which promotes to float). Fixes floor_divide, lcm, divmod, and downstream ops.
- **sign(NaN)**: `stablehlo.sign` now propagates NaN for floating-point types. MLX `sign` returns 0 for NaN; StableHLO requires NaN propagation.
- **TOTALORDER comparison**: Implements IEEE 754 total ordering for `stablehlo.compare` with `TOTALORDER` semantics, where `-NaN < -inf < ... < +inf < +NaN`. Fixes `searchsorted` with NaN values.
- **Unsigned→signed type conversion**: Works around [ml-explore/mlx#3338](https://github.com/ml-explore/mlx/issues/3338) where `mx.compile()` incorrectly fuses chained casts (e.g., `uint16→int32→float32`). Uses `view()` as a zero-cost compile barrier. Fixes mixed-type integer matmul/tensordot.
- **dot_general**: LHS and RHS dtypes are now checked independently for float promotion, fixing edge cases where one operand is float and the other is integer.
- **DetectReduceType**: Now only matches single-op reduce bodies. Multi-op bodies like logaddexp (used by `cumulative_logsumexp`) were previously misidentified as simple `max` reductions, producing silently wrong results. Now correctly reports them as unsupported.
- **TopK**: Uses negate+ascending argsort instead of ascending+reverse to preserve stable tie ordering in the returned indices.

## Test plan

- [x] All 2080 internal tests pass (`uv run pytest tests/test_ops.py -n0`)
- [x] Upstream JAX 0.9.2 suite: 25194/27535 = 91.5% passing
- [x] Verified integer division: `lax.div(int32([7,-7]), int32([2,2]))` → `[3,-3]`
- [x] Verified sign(NaN): `lax.sign(float32(nan))` → `nan`
- [x] Verified searchsorted with NaN: correct insertion points for `[-inf,...,inf,nan,nan]`
- [x] Verified mixed-type tensordot: `int8 × uint16` and `int8 × uint32` → correct results
- [x] Verified cumulative_logsumexp: now returns proper "unsupported" error instead of wrong `cummax` results
- [x] Verified TopK tie ordering: `top_k([3,3,3,3,3], 3)` → indices `[0,1,2]` (not `[4,3,2]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)