### PR TITLE
Dedup unary op lookup tables in control_flow.cc

### DIFF
--- a/src/pjrt_plugin/ops/control_flow.cc
+++ b/src/pjrt_plugin/ops/control_flow.cc
@@ -11,6 +11,7 @@
 #include <cstring>
 #include <optional>
 #include <string>
+#include <string_view>
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "pjrt_plugin/ops/handler_utils.h"
@@ -21,10 +22,11 @@ namespace jax_mps {
 namespace {
 
 // Shared unary op table used by both the mhlo.* custom_call path (HandleCustomCall)
-// and the chlo.* composite path (HandleComposite). Keyed by the bare op name; callers
-// strip the "mhlo." / "chlo." prefix before looking up.
-const std::unordered_map<std::string, UnaryMlxFn>& UnaryMlxOps() {
-    static const std::unordered_map<std::string, UnaryMlxFn> kOps = {
+// and the chlo.* composite path (HandleComposite). Keyed by the bare op name as a
+// string_view pointing into the static string literals below, so callers can
+// probe with a string_view into the original op name without allocating.
+const std::unordered_map<std::string_view, UnaryMlxFn>& UnaryMlxOps() {
+    static const std::unordered_map<std::string_view, UnaryMlxFn> kOps = {
         {"sinh", mlx::core::sinh},      {"cosh", mlx::core::cosh},
         {"tan", mlx::core::tan},        {"asin", mlx::core::arcsin},
         {"acos", mlx::core::arccos},    {"atan", mlx::core::arctan},
@@ -297,11 +299,12 @@ bool HandleCustomCall(mlir::Operation* op, ValueMap& values, std::vector<mlx::co
     }
 
     // Handle unary mhlo.* custom calls via the shared unary op table.
+    // Use string_view throughout so the lookup doesn't allocate.
     static constexpr std::string_view kMhloPrefix = "mhlo.";
-    if (callTargetName.compare(0, kMhloPrefix.size(), kMhloPrefix) == 0) {
-        auto bareName = callTargetName.substr(kMhloPrefix.size());
+    std::string_view callName{callTargetName};
+    if (callName.substr(0, kMhloPrefix.size()) == kMhloPrefix) {
         const auto& unaryOps = UnaryMlxOps();
-        auto unaryIt = unaryOps.find(bareName);
+        auto unaryIt = unaryOps.find(callName.substr(kMhloPrefix.size()));
         if (unaryIt != unaryOps.end()) {
             if (op->getNumOperands() != 1 || op->getNumResults() != 1) {
                 MPS_LOG_ERROR("stablehlo.custom_call %s: expected 1 input and 1 output\n",
@@ -971,12 +974,13 @@ bool HandleComposite(mlir::Operation* op, ValueMap& values, std::vector<mlx::cor
     }
 
     // Try native MLX dispatch for known single-input CHLO composite ops,
-    // via the shared unary op table.
+    // via the shared unary op table. Use string_view to avoid per-lookup allocation.
     static constexpr std::string_view kChloPrefix = "chlo.";
+    std::string_view compName{compositeName};
     if (inputs.size() == 1 && op->getNumResults() == 1 &&
-        compositeName.compare(0, kChloPrefix.size(), kChloPrefix) == 0) {
+        compName.substr(0, kChloPrefix.size()) == kChloPrefix) {
         const auto& unaryOps = UnaryMlxOps();
-        auto it = unaryOps.find(compositeName.substr(kChloPrefix.size()));
+        auto it = unaryOps.find(compName.substr(kChloPrefix.size()));
         if (it != unaryOps.end()) {
             values.emplace(ToKey(op->getResult(0)), it->second(inputs[0], {}));
             return true;

--- a/src/pjrt_plugin/ops/control_flow.cc
+++ b/src/pjrt_plugin/ops/control_flow.cc
@@ -20,6 +20,21 @@ namespace jax_mps {
 
 namespace {
 
+// Shared unary op table used by both the mhlo.* custom_call path (HandleCustomCall)
+// and the chlo.* composite path (HandleComposite). Keyed by the bare op name; callers
+// strip the "mhlo." / "chlo." prefix before looking up.
+const std::unordered_map<std::string, UnaryMlxFn>& UnaryMlxOps() {
+    static const std::unordered_map<std::string, UnaryMlxFn> kOps = {
+        {"sinh", mlx::core::sinh},      {"cosh", mlx::core::cosh},
+        {"tan", mlx::core::tan},        {"asin", mlx::core::arcsin},
+        {"acos", mlx::core::arccos},    {"atan", mlx::core::arctan},
+        {"asinh", mlx::core::arcsinh},  {"acosh", mlx::core::arccosh},
+        {"atanh", mlx::core::arctanh},  {"erf", mlx::core::erf},
+        {"erf_inv", mlx::core::erfinv},
+    };
+    return kOps;
+}
+
 // Convert a boolean mask to an additive attention mask (true -> 0, false -> -1e9)
 // cast to the given dtype so MLX's SDPA type check passes with float16.
 mlx::core::array BoolMaskToAdditive(const mlx::core::array& mask, mlx::core::Dtype dtype) {
@@ -281,27 +296,24 @@ bool HandleCustomCall(mlir::Operation* op, ValueMap& values, std::vector<mlx::co
         return true;
     }
 
-    // Handle unary mhlo.* custom calls
-    static const std::unordered_map<std::string, UnaryMlxFn> unaryCustomCalls = {
-        {"mhlo.erf", mlx::core::erf},       {"mhlo.sinh", mlx::core::sinh},
-        {"mhlo.cosh", mlx::core::cosh},     {"mhlo.asin", mlx::core::arcsin},
-        {"mhlo.acos", mlx::core::arccos},   {"mhlo.atan", mlx::core::arctan},
-        {"mhlo.asinh", mlx::core::arcsinh}, {"mhlo.acosh", mlx::core::arccosh},
-        {"mhlo.atanh", mlx::core::arctanh}, {"mhlo.erf_inv", mlx::core::erfinv},
-    };
-
-    auto unaryIt = unaryCustomCalls.find(callTargetName);
-    if (unaryIt != unaryCustomCalls.end()) {
-        if (op->getNumOperands() != 1 || op->getNumResults() != 1) {
-            MPS_LOG_ERROR("stablehlo.custom_call %s: expected 1 input and 1 output\n",
-                          callTargetName.c_str());
-            return false;
+    // Handle unary mhlo.* custom calls via the shared unary op table.
+    static constexpr std::string_view kMhloPrefix = "mhlo.";
+    if (callTargetName.compare(0, kMhloPrefix.size(), kMhloPrefix) == 0) {
+        auto bareName = callTargetName.substr(kMhloPrefix.size());
+        const auto& unaryOps = UnaryMlxOps();
+        auto unaryIt = unaryOps.find(bareName);
+        if (unaryIt != unaryOps.end()) {
+            if (op->getNumOperands() != 1 || op->getNumResults() != 1) {
+                MPS_LOG_ERROR("stablehlo.custom_call %s: expected 1 input and 1 output\n",
+                              callTargetName.c_str());
+                return false;
+            }
+            auto* input = RequireValue(values, op->getOperand(0), callTargetName.c_str());
+            if (!input)
+                return false;
+            values.emplace(ToKey(op->getResult(0)), unaryIt->second(*input, {}));
+            return true;
         }
-        auto* input = RequireValue(values, op->getOperand(0), callTargetName.c_str());
-        if (!input)
-            return false;
-        values.emplace(ToKey(op->getResult(0)), unaryIt->second(*input, {}));
-        return true;
     }
 
     // Handle mhlo.topk
@@ -958,21 +970,14 @@ bool HandleComposite(mlir::Operation* op, ValueMap& values, std::vector<mlx::cor
         inputs.push_back(*val);
     }
 
-    // Try native MLX dispatch for known single-input CHLO composite ops.
-    if (inputs.size() == 1 && op->getNumResults() == 1) {
-        // clang-format off
-        static const std::unordered_map<std::string, UnaryMlxFn> nativeUnary{
-            {"chlo.asin",    mlx::core::arcsin},   {"chlo.acos",    mlx::core::arccos},
-            {"chlo.atan",    mlx::core::arctan},   {"chlo.asinh",   mlx::core::arcsinh},
-            {"chlo.acosh",   mlx::core::arccosh},  {"chlo.atanh",   mlx::core::arctanh},
-            {"chlo.sinh",    mlx::core::sinh},     {"chlo.cosh",    mlx::core::cosh},
-            {"chlo.tan",     mlx::core::tan},      {"chlo.erf",     mlx::core::erf},
-            {"chlo.erf_inv", mlx::core::erfinv},
-        };
-        // clang-format on
-
-        auto it = nativeUnary.find(compositeName);
-        if (it != nativeUnary.end()) {
+    // Try native MLX dispatch for known single-input CHLO composite ops,
+    // via the shared unary op table.
+    static constexpr std::string_view kChloPrefix = "chlo.";
+    if (inputs.size() == 1 && op->getNumResults() == 1 &&
+        compositeName.compare(0, kChloPrefix.size(), kChloPrefix) == 0) {
+        const auto& unaryOps = UnaryMlxOps();
+        auto it = unaryOps.find(compositeName.substr(kChloPrefix.size()));
+        if (it != unaryOps.end()) {
             values.emplace(ToKey(op->getResult(0)), it->second(inputs[0], {}));
             return true;
         }


### PR DESCRIPTION
## Summary

- The `mhlo.*` custom_call path and the `chlo.*` composite path in `control_flow.cc` each maintained their own `std::unordered_map<std::string, UnaryMlxFn>` of the same 10–11 unary ops (sinh, cosh, tan, asin, acos, atan, asinh, acosh, atanh, erf, erf_inv).
- Extract a single shared table (`UnaryMlxOps()`) keyed by the bare op name, and have both handlers strip their respective prefix (`mhlo.` / `chlo.`) before looking up.
- No behavior change. The mhlo path now also recognizes `mhlo.tan` (was only on the chlo side), but JAX doesn't emit that today; the extra entry is dead but harmless.

## Test plan

- [x] `uv run pytest tests/test_ops.py -k "sinh or cosh or asin or acos or atan or asinh or acosh or atanh or erf or topk or top_k"` — 59 passed, 2 skipped
- [x] Full pytest via pre-commit hook — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)