### PR TITLE
Move contiguous() into TopKImplFn

### DIFF
--- a/src/pjrt_plugin/ops/control_flow.cc
+++ b/src/pjrt_plugin/ops/control_flow.cc
@@ -331,8 +331,7 @@ bool HandleCustomCall(mlir::Operation* op, ValueMap& values, std::vector<mlx::co
 
         auto resultType = mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
         int k = static_cast<int>(resultType.getShape().back());
-        auto contiguous_input = mlx::core::contiguous(*input);
-        auto [topValues, indices] = TopKImpl(contiguous_input, k);
+        auto [topValues, indices] = TopKImpl(*input, k);
         values.emplace(ToKey(op->getResult(0)), std::move(topValues));
         values.emplace(ToKey(op->getResult(1)), std::move(indices));
         return true;
@@ -995,10 +994,9 @@ bool HandleComposite(mlir::Operation* op, ValueMap& values, std::vector<mlx::cor
 
     // Handle chlo.top_k natively using shared TopKImpl
     if (inputs.size() == 1 && op->getNumResults() == 2 && compositeName == "chlo.top_k") {
-        auto input = mlx::core::contiguous(inputs[0]);
         auto resultType = mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
         int k = static_cast<int>(resultType.getShape().back());
-        auto [topValues, indices] = TopKImpl(input, k);
+        auto [topValues, indices] = TopKImpl(inputs[0], k);
         values.emplace(ToKey(op->getResult(0)), std::move(topValues));
         values.emplace(ToKey(op->getResult(1)), std::move(indices));
         return true;

--- a/src/pjrt_plugin/ops/sort_fft_complex.cc
+++ b/src/pjrt_plugin/ops/sort_fft_complex.cc
@@ -38,7 +38,9 @@ mlx::core::array DescendingKey(const mlx::core::array& input) {
 // Compute top-k values and indices along the last axis.
 // Uses a descending sort key + ascending argsort + take-first-k to preserve stable
 // tie ordering (equal values keep lowest-index-first).
-std::pair<mlx::core::array, mlx::core::array> TopKImplFn(const mlx::core::array& input, int k) {
+std::pair<mlx::core::array, mlx::core::array> TopKImplFn(const mlx::core::array& input_, int k) {
+    // argsort requires contiguous input; handle it here so callers don't have to.
+    auto input = mlx::core::contiguous(input_);
     int axis = static_cast<int>(input.ndim()) - 1;
     auto key = DescendingKey(input);
     auto allIndices = mlx::core::argsort(key, axis);
@@ -234,8 +236,7 @@ bool HandleChloTopK(mlir::Operation* op, ValueMap& values, std::vector<mlx::core
         return false;
 
     int k = static_cast<int>(topKOp.getK());
-    auto input = mlx::core::contiguous(*input_ptr);
-    auto [topValues, indices] = TopKImplFn(input, k);
+    auto [topValues, indices] = TopKImplFn(*input_ptr, k);
     values.emplace(ToKey(op->getResult(0)), std::move(topValues));
     values.emplace(ToKey(op->getResult(1)), std::move(indices));
     return true;


### PR DESCRIPTION
## Summary

- `mlx::core::argsort` requires contiguous input. All three call sites of `TopKImpl` / `TopKImplFn` (in `HandleCustomCall` for `mhlo.topk`, in `HandleComposite` for `chlo.top_k`, and in `HandleChloTopK` for the primitive `chlo.top_k`) were calling `mlx::core::contiguous()` on the input first.
- Move the `contiguous()` call inside `TopKImplFn` so callers don't have to remember, and so all three paths stay in sync by construction.

## Test plan

- [x] `uv run pytest tests/test_ops.py -k "topk or top_k or sort"` — 128 passed
- [x] Full pytest via pre-commit hook — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)