### PR TITLE
Register MPS lowerings for unary ops with native MLX equivalents

### DIFF
--- a/src/jax_plugins/mps/ops.py
+++ b/src/jax_plugins/mps/ops.py
@@ -15,7 +15,9 @@ import jax
 import jax.numpy as jnp
 from jax._src import core
 from jax._src.interpreters import mlir
+from jax._src.lax import lax as lax_lax
 from jax._src.lax import linalg as lax_linalg
+from jax._src.lax import special as lax_special
 
 # ---------------------------------------------------------------------------
 # Scaled Dot-Product Attention (mps.sdpa)
@@ -637,6 +639,23 @@ def _svd_lowering(
         ).results
 
 
+def _make_native_unary_lowering(call_target_name):
+    """Return a JAX MLIR lowering that emits a stablehlo.custom_call with the
+    given target name (expected to be one of the mhlo.* entries recognized by
+    our C++ HandleCustomCall). Keeps us off the CHLO decomposition path so the
+    unary op stays a single MLX kernel call."""
+
+    def _lowering(ctx, x):
+        (aval_out,) = ctx.avals_out
+        return mlir.custom_call(
+            call_target_name=call_target_name,
+            result_types=[mlir.aval_to_ir_type(aval_out)],
+            operands=[x],
+        ).results
+
+    return _lowering
+
+
 def register_fused_ops():
     """Register MLIR lowerings for all fused ops on the MPS platform."""
     mlir.register_lowering(_sdpa_p, _sdpa_lowering, platform="mps")
@@ -660,6 +679,35 @@ def register_fused_ops():
     mlir.register_lowering(lax_linalg.eigh_p, _eigh_lowering, platform="mps")
     mlir.register_lowering(lax_linalg.qr_p, _qr_lowering, platform="mps")
     mlir.register_lowering(lax_linalg.svd_p, _svd_lowering, platform="mps")
+
+    # Intercept unary ops that JAX would normally lower to chlo.* primitives
+    # (then decomposed to stablehlo.exp / add / etc. by CHLO legalization) and
+    # route them directly to our native MLX implementation via a
+    # stablehlo.custom_call @mhlo.* — which the C++ dispatcher handles in
+    # HandleCustomCall with a single call to mlx::core::sinh/cosh/arcsin/....
+    # Ops that JAX already lowers to a native stablehlo primitive we handle
+    # (tan, atan2) are deliberately NOT in this list.
+    _mps_native_unary_ops = [
+        (lax_lax.sinh_p, "mhlo.sinh"),
+        (lax_lax.cosh_p, "mhlo.cosh"),
+        (lax_lax.asin_p, "mhlo.asin"),
+        (lax_lax.acos_p, "mhlo.acos"),
+        (lax_lax.atan_p, "mhlo.atan"),
+        (lax_lax.asinh_p, "mhlo.asinh"),
+        (lax_lax.acosh_p, "mhlo.acosh"),
+        (lax_lax.atanh_p, "mhlo.atanh"),
+        (lax_special.erf_p, "mhlo.erf"),
+        # erf_inv is intentionally NOT intercepted: jax.random.normal uses it
+        # to transform uniform samples to Gaussian, and MLX's native erfinv
+        # differs from the CHLO-decomposed implementation in the LSB. That LSB
+        # difference propagates through random.normal → every test that uses
+        # normal inputs gets slightly different MPS vs CPU values, breaking
+        # downstream correctness comparisons that are tight by design.
+    ]
+    for prim, target in _mps_native_unary_ops:
+        mlir.register_lowering(
+            prim, _make_native_unary_lowering(target), platform="mps"
+        )
 
     # Fallback lowerings for non-MPS platforms (CPU, GPU).
     mlir.register_lowering(

--- a/src/jax_plugins/mps/ops.py
+++ b/src/jax_plugins/mps/ops.py
@@ -697,12 +697,7 @@ def register_fused_ops():
         (lax_lax.acosh_p, "mhlo.acosh"),
         (lax_lax.atanh_p, "mhlo.atanh"),
         (lax_special.erf_p, "mhlo.erf"),
-        # erf_inv is intentionally NOT intercepted: jax.random.normal uses it
-        # to transform uniform samples to Gaussian, and MLX's native erfinv
-        # differs from the CHLO-decomposed implementation in the LSB. That LSB
-        # difference propagates through random.normal → every test that uses
-        # normal inputs gets slightly different MPS vs CPU values, breaking
-        # downstream correctness comparisons that are tight by design.
+        (lax_special.erf_inv_p, "mhlo.erf_inv"),
     ]
     for prim, target in _mps_native_unary_ops:
         mlir.register_lowering(

--- a/src/jax_plugins/mps/ops.py
+++ b/src/jax_plugins/mps/ops.py
@@ -658,7 +658,14 @@ def _make_native_unary_lowering(call_target_name):
 
 
 def register_fused_ops():
-    """Register MLIR lowerings for all fused ops on the MPS platform."""
+    """Register MPS MLIR lowerings for fused custom_calls and related ops.
+
+    Covers fused forward/backward primitives (sdpa, rms_norm, layer_norm, rope,
+    gelu), linalg custom lowerings (eigh, qr, svd), CPU/GPU fallback lowerings
+    for the fused primitives, and MPS-specific lowerings of JAX unary
+    primitives (sinh, cosh, asin, acos, atan, asinh, acosh, atanh, erf,
+    erf_inv) that would otherwise decompose through CHLO.
+    """
     mlir.register_lowering(_sdpa_p, _sdpa_lowering, platform="mps")
     mlir.register_lowering(_sdpa_causal_p, _sdpa_causal_lowering, platform="mps")
     mlir.register_lowering(_rms_norm_p, _rms_norm_lowering, platform="mps")

--- a/src/jax_plugins/mps/ops.py
+++ b/src/jax_plugins/mps/ops.py
@@ -651,6 +651,7 @@ def _make_native_unary_lowering(call_target_name):
             call_target_name=call_target_name,
             result_types=[mlir.aval_to_ir_type(aval_out)],
             operands=[x],
+            backend_config="",
         ).results
 
     return _lowering

--- a/tests/configs/conv.py
+++ b/tests/configs/conv.py
@@ -14,13 +14,13 @@ def make_conv_op_configs():
                     padding="SAME",
                     dimension_numbers=("NHWC", "HWIO", "NHWC"),
                 ),
-                lambda key: random.normal(key, (2, 8, 8, 3)),
-                lambda key: random.normal(key, (3, 3, 3, 8)),
+                lambda key: random.uniform(key, (2, 8, 8, 3), minval=-1.0, maxval=1.0),
+                lambda key: random.uniform(key, (3, 3, 3, 8), minval=-1.0, maxval=1.0),
             ),
             OperationTestConfig(
                 lambda lhs, rhs: lax.conv(lhs, rhs, (1, 1), "SAME"),
-                lambda key: random.normal(key, (1, 3, 8, 8)),
-                lambda key: random.normal(key, (16, 3, 3, 3)),
+                lambda key: random.uniform(key, (1, 3, 8, 8), minval=-1.0, maxval=1.0),
+                lambda key: random.uniform(key, (16, 3, 3, 3), minval=-1.0, maxval=1.0),
                 name="lax.conv-SAME",
             ),
             OperationTestConfig(
@@ -31,8 +31,8 @@ def make_conv_op_configs():
                     padding="SAME",
                     dimension_numbers=("NWC", "WIO", "NWC"),
                 ),
-                lambda key: random.normal(key, (2, 16, 3)),
-                lambda key: random.normal(key, (3, 3, 4)),
+                lambda key: random.uniform(key, (2, 16, 3), minval=-1.0, maxval=1.0),
+                lambda key: random.uniform(key, (3, 3, 4), minval=-1.0, maxval=1.0),
                 name="lax.conv_general_dilated-1d-NWC",
             ),
             # Strided 2D convolutions with SAME padding
@@ -44,8 +44,8 @@ def make_conv_op_configs():
                     padding="SAME",
                     dimension_numbers=("NHWC", "HWIO", "NHWC"),
                 ),
-                lambda key: random.normal(key, (2, 8, 8, 3)),
-                lambda key: random.normal(key, (3, 3, 3, 8)),
+                lambda key: random.uniform(key, (2, 8, 8, 3), minval=-1.0, maxval=1.0),
+                lambda key: random.uniform(key, (3, 3, 3, 8), minval=-1.0, maxval=1.0),
                 name="lax.conv_general_dilated-stride2-SAME",
             ),
             # Asymmetric padding test
@@ -57,8 +57,8 @@ def make_conv_op_configs():
                     padding=((1, 0), (1, 0)),
                     dimension_numbers=("NHWC", "HWIO", "NHWC"),
                 ),
-                lambda key: random.normal(key, (2, 8, 8, 3)),
-                lambda key: random.normal(key, (3, 3, 3, 8)),
+                lambda key: random.uniform(key, (2, 8, 8, 3), minval=-1.0, maxval=1.0),
+                lambda key: random.uniform(key, (3, 3, 3, 8), minval=-1.0, maxval=1.0),
                 name="lax.conv_general_dilated-stride2-asymmetric",
             ),
             # Larger kernel with stride
@@ -70,8 +70,10 @@ def make_conv_op_configs():
                     padding="SAME",
                     dimension_numbers=("NHWC", "HWIO", "NHWC"),
                 ),
-                lambda key: random.normal(key, (2, 16, 16, 3)),
-                lambda key: random.normal(key, (5, 5, 3, 8)),
+                lambda key: random.uniform(
+                    key, (2, 16, 16, 3), minval=-1.0, maxval=1.0
+                ),
+                lambda key: random.uniform(key, (5, 5, 3, 8), minval=-1.0, maxval=1.0),
                 name="lax.conv_general_dilated-5x5-stride2",
             ),
             # Stride + dilation combined
@@ -84,8 +86,10 @@ def make_conv_op_configs():
                     rhs_dilation=(2, 2),
                     dimension_numbers=("NHWC", "HWIO", "NHWC"),
                 ),
-                lambda key: random.normal(key, (2, 16, 16, 3)),
-                lambda key: random.normal(key, (3, 3, 3, 8)),
+                lambda key: random.uniform(
+                    key, (2, 16, 16, 3), minval=-1.0, maxval=1.0
+                ),
+                lambda key: random.uniform(key, (3, 3, 3, 8), minval=-1.0, maxval=1.0),
                 name="lax.conv_general_dilated-stride2-dilated",
             ),
             # VALID padding with stride
@@ -97,8 +101,10 @@ def make_conv_op_configs():
                     padding="VALID",
                     dimension_numbers=("NHWC", "HWIO", "NHWC"),
                 ),
-                lambda key: random.normal(key, (2, 16, 16, 3)),
-                lambda key: random.normal(key, (3, 3, 3, 8)),
+                lambda key: random.uniform(
+                    key, (2, 16, 16, 3), minval=-1.0, maxval=1.0
+                ),
+                lambda key: random.uniform(key, (3, 3, 3, 8), minval=-1.0, maxval=1.0),
                 name="lax.conv_general_dilated-stride2-VALID",
             ),
             # 1D strided + dilated
@@ -111,8 +117,8 @@ def make_conv_op_configs():
                     rhs_dilation=(2,),
                     dimension_numbers=("NWC", "WIO", "NWC"),
                 ),
-                lambda key: random.normal(key, (2, 32, 3)),
-                lambda key: random.normal(key, (3, 3, 4)),
+                lambda key: random.uniform(key, (2, 32, 3), minval=-1.0, maxval=1.0),
+                lambda key: random.uniform(key, (3, 3, 4), minval=-1.0, maxval=1.0),
                 name="lax.conv_general_dilated-1d-stride2-dilated",
             ),
             # Large-kernel conv where kernel_size >= input_size with SAME padding.
@@ -126,8 +132,8 @@ def make_conv_op_configs():
                     padding="SAME",
                     dimension_numbers=("NHWC", "HWIO", "NHWC"),
                 ),
-                lambda key: random.normal(key, (1, 4, 4, 3)),
-                lambda key: random.normal(key, (8, 8, 3, 16)),
+                lambda key: random.uniform(key, (1, 4, 4, 3), minval=-1.0, maxval=1.0),
+                lambda key: random.uniform(key, (8, 8, 3, 16), minval=-1.0, maxval=1.0),
                 name="lax.conv_general_dilated-large-kernel",
             ),
         ]

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -294,6 +294,38 @@ def test_unsupported_op_error_message(jit: bool) -> None:
             pytest.skip("clz is now supported; test needs a new unregistered op")
 
 
+@pytest.mark.parametrize(
+    "jax_fn,target",
+    [
+        (jnp.sinh, "mhlo.sinh"),
+        (jnp.cosh, "mhlo.cosh"),
+        (jnp.arcsin, "mhlo.asin"),
+        (jnp.arccos, "mhlo.acos"),
+        (jnp.arctan, "mhlo.atan"),
+        (jnp.arcsinh, "mhlo.asinh"),
+        (jnp.arccosh, "mhlo.acosh"),
+        (jnp.arctanh, "mhlo.atanh"),
+        (jax.lax.erf, "mhlo.erf"),
+        (jax.scipy.special.erfinv, "mhlo.erf_inv"),
+    ],
+)
+def test_unary_ops_lower_to_mhlo_custom_call(jax_fn, target) -> None:
+    """Regression: ensure our MPS-platform lowerings in jax_plugins.mps.ops
+    keep these ops as stablehlo.custom_call @mhlo.<name> instead of letting
+    JAX decompose them through CHLO. A future JAX pipeline change that
+    silently reintroduces the decomposition would make this fail."""
+    if TEST_MODE == "cpu":
+        pytest.skip("MPS-specific test skipped in CPU-only mode")
+
+    device = jax.devices("mps")[0]
+    with jax.default_device(device):
+        x = jnp.ones((3,), dtype=jnp.float32)
+        ir_text = str(jax.jit(jax_fn).lower(x).compiler_ir("stablehlo"))
+    assert f"@{target}" in ir_text, (
+        f"Expected `@{target}` in lowered IR; got:\n{ir_text}"
+    )
+
+
 def test_rng_bit_generator() -> None:
     """Test that stablehlo.rng_bit_generator produces valid output and correct state."""
     OperationTestConfig.EXERCISED_STABLEHLO_OPS.add("stablehlo.rng_bit_generator")

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -320,7 +320,7 @@ def test_unary_ops_lower_to_mhlo_custom_call(jax_fn, target) -> None:
     device = jax.devices("mps")[0]
     with jax.default_device(device):
         x = jnp.ones((3,), dtype=jnp.float32)
-        ir_text = str(jax.jit(jax_fn).lower(x).compiler_ir("stablehlo"))
+        ir_text = str(jax.jit(jax_fn).lower(x).compiler_ir(dialect="stablehlo"))
     assert f"@{target}" in ir_text, (
         f"Expected `@{target}` in lowered IR; got:\n{ir_text}"
     )


### PR DESCRIPTION
## Summary

JAX lowers \`jnp.sinh / cosh / arcsin / arccos / arctan / arcsinh / arccosh / arctanh / erf / erfinv\` to \`chlo.*\` primitives, which CHLO-to-stablehlo legalization then decomposes into chains of \`stablehlo.exp / add / sqrt / ...\` — each a separate Metal kernel dispatch.

MLX has native kernels for every one of these. Register MPS-platform lowerings on the underlying \`jax.lax\` primitives (\`sinh_p\`, \`cosh_p\`, ..., \`erf_p\`, \`erf_inv_p\`) that emit \`stablehlo.custom_call @mhlo.<name>\` directly. The existing C++ \`HandleCustomCall\` dispatches those to \`mlx::core::sinh / cosh / arcsin / ...\` in one kernel call — skipping the CHLO decomposition entirely.

Verified IR transform (\`jnp.sinh\`):

\`\`\`
before:  %0 = chlo.sinh %arg0 : tensor<3xf32> -> tensor<3xf32>
after:   %0 = stablehlo.custom_call @mhlo.sinh(%arg0) ...
\`\`\`

## Deliberately excluded

- **\`tan\`, \`atan2\`**: already lower to native \`stablehlo.tan\` / \`stablehlo.atan2\` which we handle in \`arithmetic.cc\`. Nothing to intercept.

## erf_inv note & conv fixture change

Confirmed MLX's native \`erfinv\` is **more accurate** than the CHLO decomposition (max err 1.2e-7 vs 1.8e-7 against scipy float64 ground truth on linspace(-0.99, 0.99, 100)). But \`jax.random.normal\` applies \`erfinv\` near its ±1 saturation where the vertical tangent amplifies LSB input differences into ~1e-5 output differences. Four conv tests compare MPS vs CPU on \`random.normal\`-generated inputs at \`atol=1e-5\`, so the amplified divergence nudged them past tolerance.

Fix: switch conv test input/kernel generation from \`random.normal\` to \`random.uniform(minval=-1, maxval=1)\`. Conv tests verify conv correctness, not input distribution; uniform inputs bypass \`erfinv\` entirely and stay bit-compatible between MPS and CPU.

## Test plan

- [x] \`uv run pytest tests/test_ops.py\` — 2100 passed, 232 skipped, 42 xfailed (matches main)
- [x] Full pytest via pre-commit hook — passed
- [x] Manual IR inspection: \`jnp.sinh\` et al. now emit \`stablehlo.custom_call @mhlo.*\` on MPS
- [x] erfinv accuracy measurement: MPS-MLX 1.2e-7 vs CHLO 1.8e-7 vs scipy float64

🤖 Generated with [Claude Code](https://claude.com/claude-code)