### PR TITLE
Fix MLIR threadpool + MLX compiler-cache leaks

### DIFF
--- a/src/pjrt_plugin/mlx_executable.cc
+++ b/src/pjrt_plugin/mlx_executable.cc
@@ -3,6 +3,7 @@
 #include "pjrt_plugin/mlx_executable.h"
 
 #include <mlx/compile.h>
+#include <mlx/compile_impl.h>
 #include <mlx/memory.h>
 #include <mlx/mlx.h>
 
@@ -481,6 +482,16 @@ std::unique_ptr<MlxExecutable> MlxExecutable::Create(mps::ParsedModule parsed_mo
     return executable;
 }
 
+MlxExecutable::~MlxExecutable() {
+    // Drop the entry that compile(this) inserted into MLX's process-global
+    // compiler cache. Without this, the cache holds a CacheEntry — including
+    // the full traced tape and any captured constants — for the lifetime of
+    // the process, even after JAX evicts this executable.
+    if (compile_attempted_) {
+        mlx::core::detail::compile_erase(reinterpret_cast<std::uintptr_t>(this));
+    }
+}
+
 bool MlxExecutable::IsValid() const {
     return valid_;
 }
@@ -564,7 +575,13 @@ MlxExecuteResult MlxExecutable::Execute(const std::vector<MlxBuffer*>& inputs) {
             };
 
             try {
-                compiled_fn_ = mlx::core::compile(exec_fn);
+                // Use `this` as the fun_id so we can erase this executable's
+                // entry from MLX's global compiler cache in our destructor.
+                // The public compile() overload can't derive a stable id from a
+                // capturing lambda and would otherwise accumulate entries under
+                // id=0 that are never released.
+                compiled_fn_ =
+                    mlx::core::detail::compile(exec_fn, reinterpret_cast<std::uintptr_t>(this));
 
                 auto test_outputs = compiled_fn_(inputArrays);
                 if (!test_outputs.empty()) {

--- a/src/pjrt_plugin/mlx_executable.cc
+++ b/src/pjrt_plugin/mlx_executable.cc
@@ -8,6 +8,7 @@
 #include <mlx/mlx.h>
 
 #include <chrono>
+#include <cstdint>
 #include <cstdlib>
 #include <functional>
 #include <stdexcept>
@@ -483,10 +484,10 @@ std::unique_ptr<MlxExecutable> MlxExecutable::Create(mps::ParsedModule parsed_mo
 }
 
 MlxExecutable::~MlxExecutable() {
-    // Drop the entry that compile(this) inserted into MLX's process-global
-    // compiler cache. Without this, the cache holds a CacheEntry — including
-    // the full traced tape and any captured constants — for the lifetime of
-    // the process, even after JAX evicts this executable.
+    // Drop the MLX process-global compiler-cache entry keyed by `this`. Without
+    // this, the cache holds a CacheEntry — including the full traced tape and
+    // any captured constants — for the lifetime of the process, even after JAX
+    // evicts this executable.
     if (compile_attempted_) {
         mlx::core::detail::compile_erase(reinterpret_cast<std::uintptr_t>(this));
     }

--- a/src/pjrt_plugin/mlx_executable.h
+++ b/src/pjrt_plugin/mlx_executable.h
@@ -34,7 +34,7 @@ public:
     // Factory method to create executable from parsed module
     static std::unique_ptr<MlxExecutable> Create(mps::ParsedModule parsed_module);
 
-    ~MlxExecutable() = default;
+    ~MlxExecutable();
 
     bool IsValid() const;
     std::string error() const;

--- a/src/pjrt_plugin/stablehlo_parser.cc
+++ b/src/pjrt_plugin/stablehlo_parser.cc
@@ -49,6 +49,11 @@ const std::unordered_set<std::string>& getSupportedOps() {
 
 // Register all dialects needed for StableHLO parsing
 void registerDialects(mlir::MLIRContext& context) {
+    // Our StableHLO modules are tiny; MLIR's default per-context LLVM thread
+    // pool (hardware_concurrency workers) would otherwise leak ~8 worker
+    // threads per compile, since JAX caches the MlxExecutable — and thus its
+    // MLIRContext — for the lifetime of the process.
+    context.disableMultithreading();
     mlir::DialectRegistry registry;
     registry.insert<mlir::func::FuncDialect>();
     registry.insert<mlir::stablehlo::StablehloDialect>();


### PR DESCRIPTION
## Summary

Two independent leaks surfaced while watching memory grow during long JAX
test runs (Activity Monitor showed ~50 GB on the upstream JAX suite).

- **Disable per-context MLIR threadpool.** Each `MlxExecutable` heap-allocates
  its own `mlir::MLIRContext`, which lazily spawns an `llvm::DefaultThreadPool`
  sized to hardware concurrency for parallel pass execution. JAX caches our
  executables for the process lifetime, so every compile leaks ~8 idle worker
  threads. After ~3,000 compiles the JAX upstream suite accumulated ~2,900
  threads × ~8 MB reserved stack each, pushing virtual memory past 30 GB.
  Our StableHLO modules are tiny so we lose nothing by skipping the pool.

- **Release MLX compiler-cache entries on executable destruction.**
  `mlx::core::compile()` adds a `CacheEntry` (full traced tape, captured
  constants, kernel data) to a process-global cache, keyed by the function
  pointer address. Our capturing `exec_fn` lambda has no `std::function`
  target, so every compile maps to id=0 and entries pile up forever. When
  JAX evicts an `MlxExecutable`, our `compiled_fn_` goes away but MLX's
  cache entry stays. Switch to `mlx::core::detail::compile()` with `this`
  as a stable per-executable id, and call `compile_erase(id)` from the
  destructor.

## Impact

| Metric | Before | After |
|---|---|---|
| OS threads after 500 unique compiles | ~2,900 | 31 |
| `test_util_clear_cache` RSS jump | +1.9 GB | −1.5 MB |
| 200 unique JIT + `clear_caches()` RSS growth | hundreds of MB | ~2 MB |
| Our `tests/` wall time | 395 s | 232 s (40% faster, smaller MLX cache → faster lookups) |

Validated separately with `playground/thread_leak_check.py` and
`playground/cache_leak_check.py`. Also confirmed via destructor tracing
that JAX correctly destroys `MlxExecutable`s on cache eviction — the
remaining ~6 GB peak in the test suite is the macOS allocator's
high-watermark behavior (freed pages stay owned by the process and are
fully reused), not an outstanding leak.

## Test plan
- [x] `uv run pytest tests/` — 2,129 passed, 232 skipped, 42 xfailed (was 2,129 / 232 / 42 on main)
- [x] `playground/thread_leak_check.py -n 500` — +3 OS threads (was thousands)
- [x] `playground/cache_leak_check.py -n 200` — +1.8 MB total (was hundreds of MB)
- [ ] Re-run the JAX upstream test suite to confirm no regression in pass rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)