### PR TITLE
Cap MLX buffer cache to bound GPU residency growth

### DIFF
--- a/src/pjrt_plugin/mlx_client.cc
+++ b/src/pjrt_plugin/mlx_client.cc
@@ -4,6 +4,10 @@
 
 #include <mlx/mlx.h>
 
+#include <cstdlib>
+#include <exception>
+#include <string>
+
 #include "pjrt_plugin/logging.h"
 #include "pjrt_plugin/mlx_buffer.h"
 #include "pjrt_plugin/mlx_device.h"
@@ -19,7 +23,29 @@ MlxClient::MlxClient() {
     // Set MLX to use GPU (Metal) device
     mlx::core::set_default_device(mlx::core::Device::gpu);
 
-    MPS_LOG_DEBUG("MlxClient initialized with MLX GPU backend\n");
+    // Cap MLX's internal buffer cache. By default MLX sizes the cache at
+    // ~1.5x the recommended working set (tens of GB on Apple Silicon),
+    // which is fine for a long-running training script but causes the cache
+    // to grow without bound across thousands of unrelated JAX
+    // computations. The cached MTLBuffers stay in the residency set and,
+    // once the cache exceeds physical memory, are swapped to disk; we have
+    // observed 23 GB of swapped IOAccelerator memory after a full upstream
+    // JAX test run, alongside intermittent command-buffer hangs.
+    //
+    // 1 GiB is plenty to absorb hot allocations within a single
+    // computation while letting MLX evict and release MTLBuffers between
+    // unrelated computations. Override with JAX_MPS_CACHE_LIMIT_BYTES.
+    size_t cache_limit = 1ULL << 30;
+    if (const char* env = std::getenv("JAX_MPS_CACHE_LIMIT_BYTES")) {
+        try {
+            cache_limit = std::stoull(env);
+        } catch (const std::exception&) {
+            MPS_LOG_WARN("Invalid JAX_MPS_CACHE_LIMIT_BYTES=%s, using default\n", env);
+        }
+    }
+    mlx::core::set_cache_limit(cache_limit);
+
+    MPS_LOG_DEBUG("MlxClient initialized with MLX GPU backend (cache_limit=%zu)\n", cache_limit);
 }
 
 MlxClient::~MlxClient() = default;


### PR DESCRIPTION
## Summary

- MLX's `MetalAllocator` caches freed `MTLBuffer`s in an internal pool. The cap is initialized to roughly `min(1.5 × max_recommended_working_set, 0.95 × physical_memory)` — ~30 GB on a 32 GB Mac, larger elsewhere — so in practice the cache never evicts. Across thousands of unrelated JAX computations the cache grew until it filled physical memory and the OS started swapping `IOSurface` pages to disk; we observed ~23 GB of swapped `IOAccelerator` memory after a full upstream JAX suite run.
- Cap MLX's cache at 1 GiB in `MlxClient`'s constructor. Hot allocations within a single computation still reuse from cache, but freed buffers above the cap are released to Metal and removed from the residency set instead of accumulating forever. Override via `JAX_MPS_CACHE_LIMIT_BYTES`.
- This is also a strong candidate cause for the intermittent command-buffer hangs seen during the upstream suite (a stalled GPU dispatch on a swapped `IOSurface` can deadlock `MTL::SharedEvent::waitUntilSignaledValue`). The fix doesn't *prove* it resolves the hang — that needs more validation runs — but it removes the most plausible trigger.

## Demonstration

20 sequential allocations of unique 64 MB random arrays, then `delete()` + drop refs + `gc.collect()`:

| | before fix | after fix |
|--|--|--|
| after alloc | 2048 MB | 2355 MB |
| after delete + gc | **2048 MB** (no release) | **1024 MB** (capped) |

Mid-run snapshot from the upstream suite (in progress as of opening this PR), ~27% complete:

|  | before fix (full run) | after fix (so far) |
|--|--|--|
| `IOAccelerator (graphics)` | up to 23.6 GB (most swapped) | 75 MB |
| RSS | 1.5–3 GB and rising | 392 MB and dropping |

## Test plan

- [x] `uv run pytest -q` (jax-mps suite) — 2129 passed, 0 failed
- [x] Pre-commit hooks (clang-format / pyright / clang-tidy / pytest) all pass
- [ ] Full upstream JAX test suite (`scripts/run_jax_tests.py`) — running in background; will update with final pass rate + memory numbers when it completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
