### PR TITLE
feat: WhileLoopPrimitive for bounded graph execution in lax.scan

### DIFF
--- a/benchmarks/bench_rnn_training.py
+++ b/benchmarks/bench_rnn_training.py
@@ -1,0 +1,222 @@
+"""Full RNN training benchmark for jax-mps branch comparison.
+
+Measures wall-clock time for complete GRU training steps including:
+  - Forward pass through lax.scan
+  - MSE loss computation
+  - Backward pass (grad through scan)
+  - Parameter update via SGD
+
+Usage:
+  python benchmarks/bench_rnn_training.py --save pr_training.json
+  # switch branch, rebuild
+  python benchmarks/bench_rnn_training.py --save main_training.json
+  # compare
+  python benchmarks/bench_rnn_training.py --compare main_training.json pr_training.json
+"""
+
+import argparse
+import json
+import os
+import time
+from functools import partial
+
+os.environ.setdefault("JAX_PLATFORMS", "mps")
+
+import jax
+import jax.numpy as jnp
+from jax import lax, random
+
+BATCH_SIZE = 32
+SEQ_LEN = 200
+INPUT_DIM = 64
+
+# ---------------------------------------------------------------------------
+# GRU Model
+# ---------------------------------------------------------------------------
+
+
+def init_gru_params(key, input_dim, hidden_dim, output_dim):
+    """Initialize GRU + linear readout parameters."""
+    keys = random.split(key, 8)
+    def scale(shape):
+        return 1.0 / jnp.sqrt(shape[-1])
+
+    params = {
+        # GRU gates
+        "Wz": random.normal(keys[0], (input_dim, hidden_dim)) * scale((input_dim,)),
+        "Uz": random.normal(keys[1], (hidden_dim, hidden_dim)) * scale((hidden_dim,)),
+        "bz": jnp.zeros(hidden_dim),
+        "Wr": random.normal(keys[2], (input_dim, hidden_dim)) * scale((input_dim,)),
+        "Ur": random.normal(keys[3], (hidden_dim, hidden_dim)) * scale((hidden_dim,)),
+        "br": jnp.zeros(hidden_dim),
+        "Wh": random.normal(keys[4], (input_dim, hidden_dim)) * scale((input_dim,)),
+        "Uh": random.normal(keys[5], (hidden_dim, hidden_dim)) * scale((hidden_dim,)),
+        "bh": jnp.zeros(hidden_dim),
+        # Linear readout
+        "Wo": random.normal(keys[6], (hidden_dim, output_dim)) * scale((hidden_dim,)),
+        "bo": jnp.zeros(output_dim),
+    }
+    return params
+
+
+def gru_forward(params, xs, unroll):
+    """Forward pass: GRU scan over sequence, return final hidden → output."""
+    hidden_dim = params["Wz"].shape[1]
+
+    def gru_cell(h, x):
+        z = jax.nn.sigmoid(x @ params["Wz"] + h @ params["Uz"] + params["bz"])
+        r = jax.nn.sigmoid(x @ params["Wr"] + h @ params["Ur"] + params["br"])
+        h_tilde = jnp.tanh(x @ params["Wh"] + (r * h) @ params["Uh"] + params["bh"])
+        h_new = (1 - z) * h + z * h_tilde
+        return h_new, None
+
+    h0 = jnp.zeros((xs.shape[1], hidden_dim))  # (batch, hidden)
+    h_final, _ = lax.scan(gru_cell, h0, xs, unroll=unroll)
+    logits = h_final @ params["Wo"] + params["bo"]
+    return logits
+
+
+def mse_loss(params, xs, targets, unroll):
+    """MSE loss over batch."""
+    preds = gru_forward(params, xs, unroll)
+    return jnp.mean((preds - targets) ** 2)
+
+
+def train_step(params, xs, targets, lr, unroll):
+    """Single training step: forward + backward + SGD update."""
+    loss, grads = jax.value_and_grad(mse_loss)(params, xs, targets, unroll)
+    params = jax.tree.map(lambda p, g: p - lr * g, params, grads)
+    return params, loss
+
+
+# ---------------------------------------------------------------------------
+# Benchmark configs
+# ---------------------------------------------------------------------------
+
+CONFIGS = [
+    # (name, hidden_dim, output_dim)
+    ("h512", 512, 32),
+    ("h1024", 1024, 64),
+    ("h2048", 2048, 128),
+]
+
+UNROLLS = [1, 10, 50]  # full unroll added per config
+
+
+def bench_training(warmup=3, repeats=10):
+    """Run full training step benchmark across configs and unroll factors."""
+    key = random.PRNGKey(42)
+    results = {}
+
+    for name, hidden_dim, output_dim in CONFIGS:
+        k1, k2, k3, key = random.split(key, 4)
+        params = init_gru_params(k1, INPUT_DIM, hidden_dim, output_dim)
+        xs = random.normal(k2, (SEQ_LEN, BATCH_SIZE, INPUT_DIM))
+        targets = random.normal(k3, (BATCH_SIZE, output_dim))
+        lr = 0.001
+
+        unrolls = UNROLLS + [SEQ_LEN]
+
+        print(f"\n{'=' * 78}")
+        print(
+            f"  {name}: in={INPUT_DIM} hidden={hidden_dim} out={output_dim} "
+            f"T={SEQ_LEN} batch={BATCH_SIZE}"
+        )
+        print(f"{'=' * 78}")
+        print(f"  {'unroll':<14}  {'step time':>12}  {'ms/seq_step':>12}  {'loss':>12}")
+        print(f"  {'-' * 14}  {'-' * 12}  {'-' * 12}  {'-' * 12}")
+
+        config_results = {}
+        for unroll in unrolls:
+            label = f"{unroll}" if unroll < SEQ_LEN else f"{unroll} (full)"
+
+            step_jit = jax.jit(partial(train_step, lr=lr, unroll=unroll))
+
+            try:
+                # Warmup
+                p = params
+                for _ in range(warmup):
+                    p, loss = step_jit(p, xs, targets)
+                    loss.block_until_ready()
+
+                # Timed runs
+                times = []
+                p = params
+                loss = jnp.array(0.0)
+                for _ in range(repeats):
+                    t0 = time.perf_counter()
+                    p, loss = step_jit(p, xs, targets)
+                    loss.block_until_ready()
+                    times.append((time.perf_counter() - t0) * 1000)
+
+                times.sort()
+                med = times[len(times) // 2]
+                final_loss = float(loss)
+                config_results[str(unroll)] = round(med, 2)
+                print(
+                    f"  {label:<14}  {med:10.2f} ms  {med / SEQ_LEN:10.3f} ms  {final_loss:10.6f}"
+                )
+
+            except Exception as e:
+                config_results[str(unroll)] = None
+                print(f"  {label:<14}  {'FAILED':>12}  {'':>12}  {str(e)[:40]}")
+
+        results[name] = config_results
+
+    return results
+
+
+def compare(baseline_path, current_path):
+    """Compare two saved result files."""
+    with open(baseline_path) as f:
+        baseline = json.load(f)
+    with open(current_path) as f:
+        current = json.load(f)
+
+    print(f"\n{'=' * 84}")
+    print("  Full Training Step Comparison (fwd + bwd + SGD)")
+    print(f"  baseline: {baseline_path}")
+    print(f"  current:  {current_path}")
+    print(f"{'=' * 84}")
+    print(
+        f"  {'config':<10} {'unroll':>8}  {'baseline':>12}  {'current':>12}  {'speedup':>10}"
+    )
+    print(f"  {'-' * 10} {'-' * 8}  {'-' * 12}  {'-' * 12}  {'-' * 10}")
+
+    for config in baseline:
+        if config not in current:
+            continue
+        for unroll in baseline[config]:
+            b = baseline[config].get(unroll)
+            c = current[config].get(unroll)
+            if b is None or c is None:
+                status = "FAIL" if c is None else "N/A"
+                print(f"  {config:<10} {unroll:>8}  {b or 'N/A':>12}  {status:>12}")
+                continue
+            speedup = b / c
+            marker = " ✓" if speedup > 1.05 else (" ✗" if speedup < 0.95 else "")
+            print(
+                f"  {config:<10} {unroll:>8}  {b:10.2f} ms  {c:10.2f} ms  {speedup:8.2f}x{marker}"
+            )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Full RNN training benchmark")
+    parser.add_argument("--save", type=str, help="Save results to JSON file")
+    parser.add_argument(
+        "--compare",
+        nargs=2,
+        metavar=("BASELINE", "CURRENT"),
+        help="Compare two saved result files",
+    )
+    args = parser.parse_args()
+
+    if args.compare:
+        compare(args.compare[0], args.compare[1])
+    else:
+        results = bench_training()
+        if args.save:
+            with open(args.save, "w") as f:
+                json.dump(results, f, indent=2)
+            print(f"\nResults saved to {args.save}")
+        print("\nTraining benchmark complete.")

--- a/benchmarks/bench_rnn_training.py
+++ b/benchmarks/bench_rnn_training.py
@@ -38,6 +38,7 @@ INPUT_DIM = 64
 def init_gru_params(key, input_dim, hidden_dim, output_dim):
     """Initialize GRU + linear readout parameters."""
     keys = random.split(key, 8)
+
     def scale(shape):
         return 1.0 / jnp.sqrt(shape[-1])
 

--- a/src/pjrt_plugin/mlx_executable.cc
+++ b/src/pjrt_plugin/mlx_executable.cc
@@ -569,6 +569,7 @@ MlxExecuteResult MlxExecutable::Execute(const std::vector<MlxBuffer*>& inputs) {
                 ExecContext local_ctx;
                 local_ctx.module = *parsed_module_.module;
                 local_ctx.inside_compile = true;
+                local_ctx.allow_while_primitive = true;
                 if (!ExecuteFunction(parsed_module_.entry_func, inputs, outs, local_ctx)) {
                     return {};
                 }

--- a/src/pjrt_plugin/ops/control_flow.cc
+++ b/src/pjrt_plugin/ops/control_flow.cc
@@ -2,14 +2,20 @@
 // optimization_barrier).
 
 #include <mlx/compile.h>
+#include <mlx/compile_impl.h>
 #include <mlx/fast.h>
 #include <mlx/linalg.h>
+#include <mlx/primitives.h>
 #include <mlx/random.h>
 #include <mlx/transforms.h>
 
+#include <atomic>
+#include <functional>
+#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
+#include <unordered_set>
 
 #include "llvm/Support/JSON.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -91,6 +97,200 @@ bool HandleStablehloReturn(mlir::Operation* op, ValueMap& values,
     return CollectReturnValues(op, values, outputs, "stablehlo.return");
 }
 
+// Collect arrays referenced inside a region but defined outside it.
+// These must be passed as explicit inputs to mx::compile to avoid
+// the "uncaptured inputs" error. An optional `seen` set enables
+// deduplication across multiple regions (e.g., body + cond).
+//
+// Uses region.walk() to recursively traverse nested sub-regions (e.g.
+// reduce bodies, case branches) so external values used at any nesting
+// depth are captured. The isAncestor guard filters out block arguments
+// and SSA values defined inside the region at any level.
+void CollectExternalValues(mlir::Region& region, const ValueMap& values, std::vector<void*>& keys,
+                           std::vector<mlx::core::array>& arrays,
+                           std::unordered_set<void*>* seen = nullptr) {
+    std::unordered_set<void*> localSeen;
+    auto& seenRef = seen ? *seen : localSeen;
+
+    region.walk([&](mlir::Operation* op) {
+        for (auto operand : op->getOperands()) {
+            auto* key = ToKey(operand);
+            if (seenRef.count(key))
+                continue;
+
+            // Skip values defined inside this region (at any nesting level).
+            // For block arguments, check their parent region.
+            // For SSA values, check their defining op's parent region.
+            if (auto* defOp = operand.getDefiningOp()) {
+                if (region.isAncestor(defOp->getParentRegion()))
+                    continue;
+            } else {
+                // Block argument — skip if it belongs to this region or a
+                // nested sub-region (e.g. reduce body accumulators).
+                if (region.isAncestor(operand.getParentRegion()))
+                    continue;
+            }
+
+            auto it = values.find(key);
+            if (it != values.end()) {
+                seenRef.insert(key);
+                keys.push_back(key);
+                arrays.push_back(it->second);
+            }
+        }
+    });
+}
+
+// Custom MLX primitive that encapsulates a while-loop with compiled body
+// and per-step eval. This is opaque to mx::compile (won't be fused) but
+// doesn't prevent outer compilation. When eval is called on the compiled
+// graph, this primitive runs the loop with per-step eval internally.
+//
+// Stream placement: This primitive MUST run on the CPU stream, but this does
+// NOT move computation to CPU. The compiled body (compiledBody_) internally
+// dispatches GPU kernels via MLX's default GPU stream — the CPU side only
+// orchestrates the loop: call body → async_eval() to flush GPU work → update
+// loop vars → repeat. This is the same pattern as MLX's own eval() scheduler.
+//
+// Why not the GPU stream: eval()/async_eval() synchronize the GPU command
+// queue. Calling them from within a GPU stream eval callback would re-enter
+// the GPU scheduler, causing a deadlock. The CPU stream avoids this.
+
+class WhileLoopPrimitive : public mlx::core::Primitive {
+public:
+    using BodyFn =
+        std::function<std::vector<mlx::core::array>(const std::vector<mlx::core::array>&)>;
+    using CondFn =
+        std::function<std::vector<mlx::core::array>(const std::vector<mlx::core::array>&)>;
+    using CompiledFn =
+        std::function<std::vector<mlx::core::array>(const std::vector<mlx::core::array>&)>;
+
+    // condFn: evaluates the loop condition (for the initial check).
+    // bodyCondFn: evaluates body THEN cond, returns [condScalar, bodyResult0, ...].
+    //   This combined function lets us eval() the full body+cond graph
+    //   synchronously each iteration, bounding graph depth to one iteration
+    //   and avoiding async_eval deadlocks with nested WhileLoopPrimitives.
+    WhileLoopPrimitive(mlx::core::Stream stream, CondFn condFn, BodyFn bodyCondFn, size_t nLoopVars,
+                       size_t nExt)
+        : Primitive(stream),
+          cacheGuard_(std::make_shared<CacheGuard>()),
+          nLoopVars_(nLoopVars),
+          nExt_(nExt) {
+        if (stream.device != mlx::core::Device::cpu) {
+            throw std::runtime_error(
+                "WhileLoopPrimitive must be on the CPU stream \u2014 GPU stream "
+                "placement would deadlock on internal eval() calls");
+        }
+        cacheGuard_->bodyCondId = nextFnId();
+        cacheGuard_->condId = nextFnId();
+        compiledBodyCond_ =
+            mlx::core::detail::compile(std::move(bodyCondFn), cacheGuard_->bodyCondId);
+        compiledCond_ = mlx::core::detail::compile(std::move(condFn), cacheGuard_->condId);
+    }
+
+    void eval_cpu(const std::vector<mlx::core::array>& inputs,
+                  std::vector<mlx::core::array>& outputs) override {
+        eval_impl(inputs, outputs);
+    }
+
+    void eval_gpu(const std::vector<mlx::core::array>& inputs,
+                  std::vector<mlx::core::array>& outputs) override {
+        eval_impl(inputs, outputs);
+    }
+
+    const char* name() const override {
+        return "WhileLoop";
+    }
+
+    bool is_equivalent(const mlx::core::Primitive& other) const override {
+        return false;
+    }
+
+    std::vector<mlx::core::Shape> output_shapes(
+        const std::vector<mlx::core::array>& inputs) override {
+        std::vector<mlx::core::Shape> shapes;
+        shapes.reserve(nLoopVars_);
+        for (size_t i = 0; i < nLoopVars_; ++i)
+            shapes.push_back(inputs[i].shape());
+        return shapes;
+    }
+
+private:
+    void eval_impl(const std::vector<mlx::core::array>& inputs,
+                   std::vector<mlx::core::array>& outputs) {
+        // inputs = loopVars (nLoopVars_) + external values (nExt_)
+        std::vector<mlx::core::array> current(inputs.begin(), inputs.end());
+
+        // Validate input arity: loop vars + external captures.
+        if (current.size() != nLoopVars_ + nExt_)
+            throw std::runtime_error("WhileLoopPrimitive: expected " +
+                                     std::to_string(nLoopVars_ + nExt_) + " inputs, got " +
+                                     std::to_string(current.size()));
+
+        // Initial condition check (before first body execution).
+        auto initCond = compiledCond_(current);
+        if (initCond.size() != 1 || initCond[0].size() != 1)
+            throw std::runtime_error("WhileLoopPrimitive: cond must return a single scalar");
+        mlx::core::eval(initCond[0]);
+        bool condTrue = initCond[0].item<bool>();
+
+        // Loop: body+cond combined per iteration.
+        while (condTrue) {
+            auto combined = compiledBodyCond_(current);
+            if (combined.size() != 1 + nLoopVars_)
+                throw std::runtime_error("WhileLoopPrimitive: bodyCondFn returned " +
+                                         std::to_string(combined.size()) + " results, expected " +
+                                         std::to_string(1 + nLoopVars_));
+            // Synchronous eval — bounded graph, no accumulation, safe
+            // re-entry for nested WhileLoopPrimitives.
+            mlx::core::eval(combined);
+
+            // Update loop vars from combined[1..nLoopVars]
+            for (size_t j = 0; j < nLoopVars_; ++j)
+                current[j] = std::move(combined[1 + j]);
+            // Check condition from combined[0]
+            condTrue = combined[0].item<bool>();
+        }
+
+        // Synchronize final results
+        using Diff = std::vector<mlx::core::array>::difference_type;
+        std::vector<mlx::core::array> finalVars(current.begin(),
+                                                current.begin() + static_cast<Diff>(nLoopVars_));
+        mlx::core::eval(finalVars);
+
+        for (size_t i = 0; i < nLoopVars_; ++i)
+            outputs[i].copy_shared_buffer(current[i]);
+    }
+
+    CompiledFn compiledBodyCond_;  // returns [cond, body...]
+    CompiledFn compiledCond_;      // initial check only
+    size_t nLoopVars_;
+    size_t nExt_;
+
+    static std::uintptr_t nextFnId() {
+        static std::atomic<std::uintptr_t> counter{0x7F00'0000'0000'0000ULL};
+        return counter.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    // CacheGuard: shared_ptr-based ref-counted cleanup.
+    // compile_erase is called only when the LAST copy of the primitive
+    // is destroyed — safe across copy/move during graph building.
+    // Skips cleanup during process shutdown to avoid SIGSEGV on
+    // already-destroyed CompilerCache.
+    struct CacheGuard {
+        std::uintptr_t bodyCondId = 0;
+        std::uintptr_t condId = 0;
+        ~CacheGuard() {
+            if (IsProcessShuttingDown())
+                return;
+            if (bodyCondId)
+                mlx::core::detail::compile_erase(bodyCondId);
+            if (condId)
+                mlx::core::detail::compile_erase(condId);
+        }
+    };
+    std::shared_ptr<CacheGuard> cacheGuard_;
+};
 // Handler for stablehlo.while
 bool HandleWhile(mlir::Operation* op, ValueMap& values, std::vector<mlx::core::array>& outputs,
                  ExecContext& ctx) {
@@ -98,8 +298,144 @@ bool HandleWhile(mlir::Operation* op, ValueMap& values, std::vector<mlx::core::a
     if (!whileOp)
         return false;
 
+    if (ctx.inside_compile && ctx.allow_while_primitive) {
+        // --- Custom primitive approach ---
+        // Instead of throwing CompileIncompatibleError, we create a
+        // WhileLoopPrimitive that is opaque to mx::compile but runs the
+        // loop with compiled body + per-step eval when eval'd.
+
+        std::vector<mlx::core::array> loopVars;
+        for (auto operand : op->getOperands()) {
+            auto* val = RequireValue(values, operand, "stablehlo.while");
+            if (!val)
+                return false;
+            loopVars.push_back(*val);
+        }
+
+        auto& condRegion = whileOp.getCond();
+        auto& bodyRegion = whileOp.getBody();
+        const size_t nLoopVars = loopVars.size();
+
+        // Collect external values referenced by body and cond regions.
+        std::vector<void*> extKeys;
+        std::vector<mlx::core::array> extArrays;
+        std::unordered_set<void*> seen;
+        CollectExternalValues(bodyRegion, values, extKeys, extArrays, &seen);
+        CollectExternalValues(condRegion, values, extKeys, extArrays, &seen);
+
+        const size_t nExt = extKeys.size();
+        auto module = ctx.module;
+
+        // Build primitive inputs: loopVars + external values
+        std::vector<mlx::core::array> primInputs = loopVars;
+        primInputs.insert(primInputs.end(), extArrays.begin(), extArrays.end());
+
+        // Build output shapes/dtypes (same as loopVars)
+        std::vector<mlx::core::Shape> outShapes;
+        outShapes.reserve(nLoopVars);
+        std::vector<mlx::core::Dtype> outDtypes;
+        outDtypes.reserve(nLoopVars);
+        for (size_t i = 0; i < nLoopVars; ++i) {
+            outShapes.push_back(loopVars[i].shape());
+            outDtypes.push_back(loopVars[i].dtype());
+        }
+
+        // Build condFn for initial condition check
+        auto condFn =
+            [&condRegion, module, extKeys, nLoopVars,
+             nExt](const std::vector<mlx::core::array>& inputs) -> std::vector<mlx::core::array> {
+            using Diff = std::vector<mlx::core::array>::difference_type;
+            auto args = std::vector<mlx::core::array>(
+                inputs.begin(), inputs.begin() + static_cast<Diff>(nLoopVars));
+            ValueMap parentVals;
+            for (size_t i = 0; i < nExt; ++i)
+                parentVals.emplace(extKeys[i], inputs[nLoopVars + i]);
+            std::vector<mlx::core::array> results;
+            ExecContext compileCtx;
+            compileCtx.module = module;
+            compileCtx.inside_compile = true;
+            compileCtx.allow_while_primitive = true;
+            if (!ExecuteRegion(condRegion, args, results, compileCtx, &parentVals))
+                throw std::runtime_error("WhileLoopPrimitive: cond region execution failed");
+            return results;
+        };
+
+        // Build combined body+cond function.
+        // Executes body region, then cond region on the body outputs.
+        // Returns [condScalar, bodyResult0, bodyResult1, ...].
+        // This lets eval_impl call eval() synchronously each iteration,
+        // bounding graph depth and avoiding async_eval deadlocks.
+        auto bodyCondFn =
+            [&bodyRegion, &condRegion, module, extKeys, nLoopVars,
+             nExt](const std::vector<mlx::core::array>& inputs) -> std::vector<mlx::core::array> {
+            using Diff = std::vector<mlx::core::array>::difference_type;
+            auto args = std::vector<mlx::core::array>(
+                inputs.begin(), inputs.begin() + static_cast<Diff>(nLoopVars));
+            ValueMap parentVals;
+            for (size_t i = 0; i < nExt; ++i)
+                parentVals.emplace(extKeys[i], inputs[nLoopVars + i]);
+
+            // Execute body
+            std::vector<mlx::core::array> bodyResults;
+            ExecContext bodyCtx;
+            bodyCtx.module = module;
+            bodyCtx.inside_compile = true;
+            bodyCtx.allow_while_primitive = true;
+            if (!ExecuteRegion(bodyRegion, args, bodyResults, bodyCtx, &parentVals))
+                throw std::runtime_error("WhileLoopPrimitive: body region failed");
+
+            // Execute cond on body results (new loop vars)
+            ValueMap condParentVals;
+            for (size_t i = 0; i < nExt; ++i)
+                condParentVals.emplace(extKeys[i], inputs[nLoopVars + i]);
+            std::vector<mlx::core::array> condResults;
+            ExecContext condCtx;
+            condCtx.module = module;
+            condCtx.inside_compile = true;
+            condCtx.allow_while_primitive = true;
+            if (!ExecuteRegion(condRegion, bodyResults, condResults, condCtx, &condParentVals))
+                throw std::runtime_error("WhileLoopPrimitive: cond region failed");
+            if (condResults.size() != 1 || condResults[0].size() != 1)
+                throw std::runtime_error("WhileLoopPrimitive: cond must return a single scalar");
+
+            // Return [condScalar, bodyResult0, bodyResult1, ...]
+            std::vector<mlx::core::array> combined;
+            combined.reserve(1 + bodyResults.size());
+            combined.push_back(condResults[0]);
+            combined.insert(combined.end(), bodyResults.begin(), bodyResults.end());
+            return combined;
+        };
+
+        // CPU stream for orchestration only — the compiled body dispatches GPU
+        // kernels internally. eval()/async_eval() calls inside the loop would
+        // deadlock on a GPU stream (see WhileLoopPrimitive class comment).
+        auto cpuStream = mlx::core::default_stream(mlx::core::Device::cpu);
+        auto prim = std::make_shared<WhileLoopPrimitive>(cpuStream, std::move(condFn),
+                                                         std::move(bodyCondFn), nLoopVars, nExt);
+
+        auto outputArrays =
+            mlx::core::array::make_arrays(std::move(outShapes), outDtypes, prim, primInputs);
+        for (size_t i = 0; i < nLoopVars; ++i)
+            values.emplace(ToKey(op->getResult(i)), std::move(outputArrays[i]));
+        return true;
+    }
+
+    // inside_compile == true but allow_while_primitive == false:
+    // This only happens for nested while-loops inside the *eager* (non-JIT)
+    // path's mx::compile optimization probe (lines below). That probe
+    // captures &values by reference, so a WhileLoopPrimitive created here
+    // would bake stale external values as constants → infinite loop.
+    //
+    // Under jax.jit(), the PJRT compile path (mlx_executable.cc) sets
+    // allow_while_primitive=true, so nested while-loops always take the
+    // WhileLoopPrimitive path above and never reach here.
+    //
+    // Throwing causes the probe to fail gracefully, falling back to the
+    // uncompiled ExecuteRegion loop for this outer while.
     if (ctx.inside_compile) {
-        throw CompileIncompatibleError("stablehlo.while requires eval()");
+        throw CompileIncompatibleError(
+            "stablehlo.while: nested while-loops are not supported in the "
+            "eager compile-probe path; falling back to uncompiled execution");
     }
 
     std::vector<mlx::core::array> loopVars;

--- a/src/pjrt_plugin/ops/control_flow.cc
+++ b/src/pjrt_plugin/ops/control_flow.cc
@@ -145,14 +145,15 @@ void CollectExternalValues(mlir::Region& region, const ValueMap& values, std::ve
 // graph, this primitive runs the loop with per-step eval internally.
 //
 // Stream placement: This primitive MUST run on the CPU stream, but this does
-// NOT move computation to CPU. The compiled body (compiledBody_) internally
-// dispatches GPU kernels via MLX's default GPU stream — the CPU side only
-// orchestrates the loop: call body → async_eval() to flush GPU work → update
-// loop vars → repeat. This is the same pattern as MLX's own eval() scheduler.
+// NOT move computation to CPU. The compiled body+cond function
+// (compiledBodyCond_) internally dispatches GPU kernels via MLX's default GPU
+// stream — the CPU side only orchestrates the loop: call body+cond →
+// mlx::core::eval() to flush + sync GPU work → read scalar cond → update loop
+// vars → repeat.
 //
-// Why not the GPU stream: eval()/async_eval() synchronize the GPU command
-// queue. Calling them from within a GPU stream eval callback would re-enter
-// the GPU scheduler, causing a deadlock. The CPU stream avoids this.
+// Why not the GPU stream: eval() synchronizes the GPU command queue. Calling
+// it from within a GPU stream eval callback would re-enter the GPU scheduler,
+// causing a deadlock. The CPU stream avoids this.
 
 class WhileLoopPrimitive : public mlx::core::Primitive {
 public:

--- a/src/pjrt_plugin/ops/control_flow.cc
+++ b/src/pjrt_plugin/ops/control_flow.cc
@@ -2,14 +2,12 @@
 // optimization_barrier).
 
 #include <mlx/compile.h>
-#include <mlx/compile_impl.h>
 #include <mlx/fast.h>
 #include <mlx/linalg.h>
 #include <mlx/primitives.h>
 #include <mlx/random.h>
 #include <mlx/transforms.h>
 
-#include <atomic>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -173,7 +171,8 @@ public:
     WhileLoopPrimitive(mlx::core::Stream stream, CondFn condFn, BodyFn bodyCondFn, size_t nLoopVars,
                        size_t nExt)
         : Primitive(stream),
-          cacheGuard_(std::make_shared<CacheGuard>()),
+          compiledBodyCond_(mlx::core::compile(std::move(bodyCondFn))),
+          compiledCond_(mlx::core::compile(std::move(condFn))),
           nLoopVars_(nLoopVars),
           nExt_(nExt) {
         if (stream.device.type != mlx::core::Device::cpu) {
@@ -181,11 +180,6 @@ public:
                 "WhileLoopPrimitive must be on the CPU stream \u2014 GPU stream "
                 "placement would deadlock on internal eval() calls");
         }
-        cacheGuard_->bodyCondId = nextFnId();
-        cacheGuard_->condId = nextFnId();
-        compiledBodyCond_ =
-            mlx::core::detail::compile(std::move(bodyCondFn), cacheGuard_->bodyCondId);
-        compiledCond_ = mlx::core::detail::compile(std::move(condFn), cacheGuard_->condId);
     }
 
     void eval_cpu(const std::vector<mlx::core::array>& inputs,
@@ -262,34 +256,13 @@ private:
             outputs[i].copy_shared_buffer(current[i]);
     }
 
+    // Public mlx::core::compile() returns a std::function whose internal
+    // shared_ptr deleter calls compile_erase when the last copy dies. Cache
+    // eviction is tied to this primitive's lifetime — no manual erase needed.
     CompiledFn compiledBodyCond_;  // returns [cond, body...]
     CompiledFn compiledCond_;      // initial check only
     size_t nLoopVars_;
     size_t nExt_;
-
-    static std::uintptr_t nextFnId() {
-        static std::atomic<std::uintptr_t> counter{0x7F00'0000'0000'0000ULL};
-        return counter.fetch_add(1, std::memory_order_relaxed);
-    }
-
-    // CacheGuard: shared_ptr-based ref-counted cleanup.
-    // compile_erase is called only when the LAST copy of the primitive
-    // is destroyed — safe across copy/move during graph building.
-    // Skips cleanup during process shutdown to avoid SIGSEGV on
-    // already-destroyed CompilerCache.
-    struct CacheGuard {
-        std::uintptr_t bodyCondId = 0;
-        std::uintptr_t condId = 0;
-        ~CacheGuard() {
-            if (IsProcessShuttingDown())
-                return;
-            if (bodyCondId)
-                mlx::core::detail::compile_erase(bodyCondId);
-            if (condId)
-                mlx::core::detail::compile_erase(condId);
-        }
-    };
-    std::shared_ptr<CacheGuard> cacheGuard_;
 };
 // Handler for stablehlo.while
 bool HandleWhile(mlir::Operation* op, ValueMap& values, std::vector<mlx::core::array>& outputs,

--- a/src/pjrt_plugin/ops/control_flow.cc
+++ b/src/pjrt_plugin/ops/control_flow.cc
@@ -176,7 +176,7 @@ public:
           cacheGuard_(std::make_shared<CacheGuard>()),
           nLoopVars_(nLoopVars),
           nExt_(nExt) {
-        if (stream.device != mlx::core::Device::cpu) {
+        if (stream.device.type != mlx::core::Device::cpu) {
             throw std::runtime_error(
                 "WhileLoopPrimitive must be on the CPU stream \u2014 GPU stream "
                 "placement would deadlock on internal eval() calls");

--- a/src/pjrt_plugin/ops/handler_utils.h
+++ b/src/pjrt_plugin/ops/handler_utils.h
@@ -3,6 +3,8 @@
 
 #include <mlx/mlx.h>
 
+#include <atomic>
+#include <cstdlib>
 #include <functional>
 #include <optional>
 #include <stdexcept>
@@ -23,6 +25,26 @@
 
 namespace jax_mps {
 
+// Process-global shutdown flag. Guards compile_erase calls that may run
+// during process teardown — the MLX CompilerCache (a function-local static)
+// may already be destroyed, and calling compile_erase would SIGSEGV.
+// The atexit hook is registered at static-init time, before the CompilerCache
+// is first used, so it fires after the cache destructor in LIFO order.
+inline std::atomic<bool>& ProcessShutdownFlag() {
+    static std::atomic<bool> flag{false};
+    return flag;
+}
+
+inline const int kProcessShutdownHookInstalled = [] {
+    std::atexit([] { ProcessShutdownFlag().store(true, std::memory_order_relaxed); });
+    return 0;
+}();
+
+inline bool IsProcessShuttingDown() {
+    (void)kProcessShutdownHookInstalled;
+    return ProcessShutdownFlag().load(std::memory_order_relaxed);
+}
+
 // Value map type using void* as key (from mlir::Value's opaque pointer)
 using ValueMap = std::unordered_map<void*, mlx::core::array>;
 
@@ -30,6 +52,10 @@ using ValueMap = std::unordered_map<void*, mlx::core::array>;
 struct ExecContext {
     mlir::ModuleOp module;
     bool inside_compile = false;  // true when running inside mlx::core::compile()
+    // true only when external values are threaded as explicit function inputs
+    // (PJRT compile path, WhileLoopPrimitive body/cond lambdas). false in
+    // non-compile probe lambdas where &values is a closure capture.
+    bool allow_while_primitive = false;
 };
 
 // Exception thrown when an op is incompatible with mlx::core::compile() tracing.

--- a/src/pjrt_plugin/ops/handler_utils.h
+++ b/src/pjrt_plugin/ops/handler_utils.h
@@ -3,7 +3,6 @@
 
 #include <mlx/mlx.h>
 
-#include <atomic>
 #include <cstdlib>
 #include <functional>
 #include <optional>
@@ -24,26 +23,6 @@
 #include "pjrt_plugin/type_utils.h"
 
 namespace jax_mps {
-
-// Process-global shutdown flag. Guards compile_erase calls that may run
-// during process teardown — the MLX CompilerCache (a function-local static)
-// may already be destroyed, and calling compile_erase would SIGSEGV.
-// The atexit hook is registered at static-init time, before the CompilerCache
-// is first used, so it fires after the cache destructor in LIFO order.
-inline std::atomic<bool>& ProcessShutdownFlag() {
-    static std::atomic<bool> flag{false};
-    return flag;
-}
-
-inline const int kProcessShutdownHookInstalled = [] {
-    std::atexit([] { ProcessShutdownFlag().store(true, std::memory_order_relaxed); });
-    return 0;
-}();
-
-inline bool IsProcessShuttingDown() {
-    (void)kProcessShutdownHookInstalled;
-    return ProcessShutdownFlag().load(std::memory_order_relaxed);
-}
 
 // Value map type using void* as key (from mlir::Value's opaque pointer)
 using ValueMap = std::unordered_map<void*, mlx::core::array>;

--- a/src/pjrt_plugin/ops/handler_utils.h
+++ b/src/pjrt_plugin/ops/handler_utils.h
@@ -3,7 +3,6 @@
 
 #include <mlx/mlx.h>
 
-#include <cstdlib>
 #include <functional>
 #include <optional>
 #include <stdexcept>

--- a/src/pjrt_plugin/pjrt_mutex.h
+++ b/src/pjrt_plugin/pjrt_mutex.h
@@ -1,11 +1,14 @@
 // Global mutex for serializing all PJRT operations that touch MLX.
 // MLX's Metal backend is not thread-safe, so concurrent calls from jaxlib
 // (e.g. test_concurrent_jit) cause SIGABRT.
+//
+// Uses std::recursive_mutex because WhileLoopPrimitive callbacks re-enter
+// Execute() while the outer Execute() still holds the lock.
 #pragma once
 
 #include <mutex>
 
-inline std::mutex& GetPjrtGlobalMutex() {
-    static std::mutex mutex;
+inline std::recursive_mutex& GetPjrtGlobalMutex() {
+    static std::recursive_mutex mutex;
     return mutex;
 }

--- a/tests/configs/control_flow.py
+++ b/tests/configs/control_flow.py
@@ -21,6 +21,20 @@ def _func_call_with_scan(x):
     return jax.jit(_inner_fn_with_scan)(x).sum()
 
 
+def _long_scan_grad(xs, alpha):
+    """Long scan + grad — regression for issue #134 (unbounded graph growth on
+    reverse-mode AD through lax.scan caused metal::malloc to exhaust at large
+    iteration counts). WhileLoopPrimitive bounds graph depth via per-iter eval.
+    """
+
+    def body(carry, x_t):
+        new = carry * jnp.float32(0.99) + x_t * alpha
+        return new, new
+
+    _, ys = lax.scan(body, jnp.float32(0.0), xs)
+    return ys.sum()
+
+
 @jax.checkpoint
 def _checkpointed_fn(x):
     """Checkpointed function that generates optimization_barrier in StableHLO."""
@@ -35,6 +49,13 @@ def make_control_flow_op_configs():
                 _func_call_with_scan,
                 lambda key: random.normal(key, (8,)),
                 name="func_call.scan",
+            ),
+            # ==================== long scan + grad (issue #134) ====================
+            OperationTestConfig(
+                _long_scan_grad,
+                lambda key: random.normal(key, (2000,)),
+                numpy.float32(0.5),
+                name="lax.scan.long_grad",
             ),
             # ==================== jax.checkpoint / optimization_barrier (issue #91) ====================
             OperationTestConfig(


### PR DESCRIPTION
Add `WhileLoopPrimitive`, a custom MLX primitive that executes `stablehlo.while` loops with per-iteration `eval()` to bound graph depth. This prevents the `metal::malloc` resource limit crash that occurs when reverse-mode AD through `lax.scan` builds an unbounded computation graph.

Fixes #134, addresses #83.

## Key Changes

### `WhileLoopPrimitive` (`control_flow.cc`)
- Custom `mlx::core::Primitive` that runs on the CPU stream, orchestrating compiled body+cond functions with per-step `eval()`.
- External values are threaded as explicit inputs (via `CollectExternalValues`) to avoid closure-capture issues with `mx::compile`.
- Body+cond compiled via the **public** `mlx::core::compile()` overload — the returned `std::function` owns the cache entry through a `shared_ptr` deleter that calls `compile_erase` automatically when the primitive's last copy dies. No manual cache bookkeeping or shutdown guard needed (matches the `MlxExecutable` pattern post-#146/#148).
- Defensive validation: CPU stream assertion before compilation, `condResults` arity check before indexing.

### `pjrt_mutex.h`
- Process-global recursive mutex for re-entrant `Execute()` calls during `WhileLoopPrimitive::eval_impl()`.

### `bench_rnn_training.py`
- GRU training benchmark exercising grad-through-scan.

### `tests/configs/control_flow.py`
- New `lax.scan.long_grad` regression config: 2000-iter scan with reverse-mode AD through a differentiable scalar, mirroring #134's pattern. Exercises the bounded-graph path under both jit and eager.

## Design

The primitive is transparent to `mx::compile` tracing — it appears as an opaque node whose `eval_impl` internally dispatches compiled GPU kernels. Nested while-loops are supported in the PJRT compile path (`allow_while_primitive=true`); the eager path falls back to uncompiled `ExecuteRegion` for nested cases.

## Testing

- All control-flow tests pass locally (MPS + CPU), including the new `lax.scan.long_grad` regression.
- Full local suite: 2137 passed, 232 skipped, 38 xfailed.
- `scripts/run_jax_tests.py` runs to completion.

## Rebase / cleanup notes

Branch was rebased onto current `main` (post-#146 / #147 / #148). Resolved one conflict in `mlx_executable.cc` by adopting `main`'s `~MlxExecutable() = default` (per #148, the detach-on-destroy patch was dropped). A follow-up cleanup commit then drops the now-redundant `IsProcessShuttingDown` / `CacheGuard` / `mlx::core::detail::compile` plumbing in favor of the public compile API, matching the rationale in #148.