### PR TITLE
Drop default 1 GiB MLX cache cap; scope it to the test runner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ uv run pytest -m benchmark --benchmark-only -n0
 
 - `JAX_MPS_NO_OPTIMIZE=1` disables the StableHLO simplification + MPS fusion passes. Useful for bisecting whether a regression comes from a fusion.
 - `JAX_MPS_DUMP_OPTIMIZED_IR=<dir>` writes each parsed+optimized module as `<dir>/module_<n>.mlir` (post-pass, so `@mps.*` custom_calls from fusion are visible). Used by `tests/test_fusion.py`; also handy for ad-hoc inspection.
+- `JAX_MPS_CACHE_LIMIT_BYTES=<n>` caps MLX's internal MTLBuffer cache (calls `mlx::core::set_cache_limit`). Unset by default — MLX picks ~1.5x the recommended working set. Set this when running many unrelated computations in one process (e.g. the upstream JAX suite via `scripts/run_jax_tests.py`, which sets 1 GiB) to prevent freed buffers from accumulating until the OS swaps them. Avoid for training/inference: a low cap forces per-iteration reallocation and regresses throughput on Max-class GPUs.
 
 # Adding New Fusion Patterns
 

--- a/scripts/run_jax_tests.py
+++ b/scripts/run_jax_tests.py
@@ -187,7 +187,17 @@ def main():
         cmd += [f"--memory-csv={args.memory_csv}"]
     if args.current_test_file:
         cmd += [f"--current-test-file={args.current_test_file}"]
-    env = {**os.environ, "JAX_PLATFORMS": "mps"}
+    # Cap MLX's buffer cache for the test-suite scenario: thousands of
+    # unrelated computations in one process otherwise leave freed MTLBuffers
+    # resident until they swap (see #134, #139). Real workloads keep MLX's
+    # tuned default; only the test runner sets this.
+    env = {
+        **os.environ,
+        "JAX_PLATFORMS": "mps",
+        "JAX_MPS_CACHE_LIMIT_BYTES": os.environ.get(
+            "JAX_MPS_CACHE_LIMIT_BYTES", str(1 << 30)
+        ),
+    }
     if args.memory_csv or args.current_test_file:
         # Make the local plugin importable from the scripts/ directory.
         scripts_dir = str(Path(__file__).resolve().parent)

--- a/src/pjrt_plugin/mlx_client.cc
+++ b/src/pjrt_plugin/mlx_client.cc
@@ -50,11 +50,16 @@ MlxClient::MlxClient() {
             }
         }
         if (!ok || pos != s.size()) {
-            MPS_LOG_WARN("Invalid JAX_MPS_CACHE_LIMIT_BYTES=%s, leaving MLX default\n", env);
-        } else {
-            mlx::core::set_cache_limit(cache_limit);
-            MPS_LOG_DEBUG("MlxClient cache_limit set to %zu\n", cache_limit);
+            // Caller meant to set a cap and got it wrong. Fall back to 1 GiB
+            // rather than the MLX default — a typo shouldn't silently
+            // re-enable unbounded residency growth in the scenarios that
+            // motivated this knob (long multi-computation processes).
+            cache_limit = 1ULL << 30;
+            MPS_LOG_WARN("Invalid JAX_MPS_CACHE_LIMIT_BYTES=%s, falling back to %zu\n", env,
+                         cache_limit);
         }
+        mlx::core::set_cache_limit(cache_limit);
+        MPS_LOG_DEBUG("MlxClient cache_limit set to %zu\n", cache_limit);
     }
 
     MPS_LOG_DEBUG("MlxClient initialized with MLX GPU backend\n");

--- a/src/pjrt_plugin/mlx_client.cc
+++ b/src/pjrt_plugin/mlx_client.cc
@@ -23,25 +23,24 @@ MlxClient::MlxClient() {
     // Set MLX to use GPU (Metal) device
     mlx::core::set_default_device(mlx::core::Device::gpu);
 
-    // Cap MLX's internal buffer cache. By default MLX sizes the cache at
-    // ~1.5x the recommended working set (tens of GB on Apple Silicon),
-    // which is fine for a long-running training script but causes the cache
-    // to grow without bound across thousands of unrelated JAX
-    // computations. The cached MTLBuffers stay in the residency set and,
-    // once the cache exceeds physical memory, are swapped to disk; we have
-    // observed 23 GB of swapped IOAccelerator memory after a full upstream
-    // JAX test run, alongside intermittent command-buffer hangs.
+    // Optional cap on MLX's internal buffer cache. MLX's own default sizes the
+    // cache at ~1.5x the recommended working set (tens of GB on Apple Silicon),
+    // which matches what training/inference workloads actually want — a hard
+    // 1 GiB cap caused 30–70% regressions on Max-class GPUs (#134) because each
+    // training iteration evicts and reallocates MTLBuffers.
     //
-    // 1 GiB is plenty to absorb hot allocations within a single
-    // computation while letting MLX evict and release MTLBuffers between
-    // unrelated computations. Override with JAX_MPS_CACHE_LIMIT_BYTES.
-    size_t cache_limit = 1ULL << 30;
+    // The pathological case the cap was originally added for (#139) is the
+    // upstream JAX test suite: thousands of unrelated computations in one
+    // process, where freed MTLBuffers stay resident and eventually swap. That
+    // scenario sets JAX_MPS_CACHE_LIMIT_BYTES explicitly via
+    // scripts/run_jax_tests.py.
     if (const char* env = std::getenv("JAX_MPS_CACHE_LIMIT_BYTES")) {
         // std::stoull accepts a leading '-' (wraps to a huge unsigned) and
         // silently stops at trailing junk like "1024abc". Validate
         // explicitly so a typo doesn't accidentally disable the cap.
         std::string s(env);
         size_t pos = 0;
+        size_t cache_limit = 0;
         bool ok = !s.empty() && s.find('-') == std::string::npos;
         if (ok) {
             try {
@@ -51,13 +50,14 @@ MlxClient::MlxClient() {
             }
         }
         if (!ok || pos != s.size()) {
-            MPS_LOG_WARN("Invalid JAX_MPS_CACHE_LIMIT_BYTES=%s, using default\n", env);
-            cache_limit = 1ULL << 30;
+            MPS_LOG_WARN("Invalid JAX_MPS_CACHE_LIMIT_BYTES=%s, leaving MLX default\n", env);
+        } else {
+            mlx::core::set_cache_limit(cache_limit);
+            MPS_LOG_DEBUG("MlxClient cache_limit set to %zu\n", cache_limit);
         }
     }
-    mlx::core::set_cache_limit(cache_limit);
 
-    MPS_LOG_DEBUG("MlxClient initialized with MLX GPU backend (cache_limit=%zu)\n", cache_limit);
+    MPS_LOG_DEBUG("MlxClient initialized with MLX GPU backend\n");
 }
 
 MlxClient::~MlxClient() = default;


### PR DESCRIPTION
## Summary

The 1 GiB `mlx::core::set_cache_limit` introduced in #139 regressed training/inference 30–70% on Max-class GPUs (M3 Max, M5 Max). Each iteration of a training step churned the cache and reallocated `MTLBuffer`s. M4 Air was unaffected because its `recommendedMaxWorkingSetSize` is small enough that 1 GiB doesn't bind, which is why it slipped past local testing.

The cap was originally added for the upstream JAX test-suite scenario: thousands of unrelated computations in one process where freed `MTLBuffer`s stay resident until the OS swaps them (~23 GB of swapped IOAccelerator memory observed). That's a test-harness problem, not a workload problem — so set the cap explicitly in `scripts/run_jax_tests.py` (1 GiB, overridable) and let real workloads use MLX's tuned default.

Credit to @tsumme1 for the bisect (in the issue thread) that pinpointed #139, and to @imkow for confirming on M5 Max.

## Changes

- `src/pjrt_plugin/mlx_client.cc`: only call `set_cache_limit` when `JAX_MPS_CACHE_LIMIT_BYTES` is set; otherwise leave MLX's default in place. A malformed env value falls back to 1 GiB (with a warning) so a typo in the test runner can't silently re-enable unbounded residency.
- `scripts/run_jax_tests.py`: set `JAX_MPS_CACHE_LIMIT_BYTES=1<<30` for the test-suite run (overridable from the environment).
- `CLAUDE.md`: document the env var under Debugging.

## Test plan

- [x] `uv run pytest tests/ -x -q` — 2129 passed, 232 skipped, 42 xfailed.
- [x] Pre-commit hooks pass (clang-format / ruff / pyright / clang-tidy / pytest).
- [ ] Confirmation from @tsumme1 / @imkow that GRU benchmark returns to v0.9.13 baseline at h=1024 / h=2048.
- [ ] Re-run `scripts/run_jax_tests.py` to confirm cap still keeps `IOAccelerator` residency bounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)