### PR TITLE
Fix UAF in MLX CompilerCache during teardown; switch MlxExecutable to public compile API

### DIFF
--- a/src/pjrt_plugin/mlx_executable.cc
+++ b/src/pjrt_plugin/mlx_executable.cc
@@ -3,7 +3,6 @@
 #include "pjrt_plugin/mlx_executable.h"
 
 #include <mlx/compile.h>
-#include <mlx/compile_impl.h>
 #include <mlx/memory.h>
 #include <mlx/mlx.h>
 
@@ -492,15 +491,7 @@ std::unique_ptr<MlxExecutable> MlxExecutable::Create(mps::ParsedModule parsed_mo
     return executable;
 }
 
-MlxExecutable::~MlxExecutable() {
-    // Drop the MLX process-global compiler-cache entry keyed by `this`. Without
-    // this, the cache holds a CacheEntry — including the full traced tape and
-    // any captured constants — for the lifetime of the process, even after JAX
-    // evicts this executable.
-    if (compile_attempted_) {
-        mlx::core::detail::compile_erase(reinterpret_cast<std::uintptr_t>(this));
-    }
-}
+MlxExecutable::~MlxExecutable() = default;
 
 bool MlxExecutable::IsValid() const {
     return valid_;
@@ -585,13 +576,11 @@ MlxExecuteResult MlxExecutable::Execute(const std::vector<MlxBuffer*>& inputs) {
             };
 
             try {
-                // Use `this` as the fun_id so we can erase this executable's
-                // entry from MLX's global compiler cache in our destructor.
-                // The public compile() overload can't derive a stable id from a
-                // capturing lambda and would otherwise accumulate entries under
-                // id=0 that are never released.
-                compiled_fn_ =
-                    mlx::core::detail::compile(exec_fn, reinterpret_cast<std::uintptr_t>(this));
+                // Public compile() overload wraps capturing closures in a
+                // shared_ptr whose deleter calls compile_erase when the
+                // returned std::function dies — eviction is tied to
+                // compiled_fn_'s lifetime, no manual erase needed.
+                compiled_fn_ = mlx::core::compile(exec_fn);
 
                 auto test_outputs = compiled_fn_(inputArrays);
                 if (!test_outputs.empty()) {

--- a/third_party/mlx/patches/07-compiler-cache-detach-on-destroy.patch
+++ b/third_party/mlx/patches/07-compiler-cache-detach-on-destroy.patch
@@ -1,0 +1,36 @@
+diff --git a/mlx/compile.cpp b/mlx/compile.cpp
+index 6f3d89c..8e013f0 100644
+--- a/mlx/compile.cpp
++++ b/mlx/compile.cpp
+@@ -372,7 +372,15 @@ class CompilerCache {
+   }
+ 
+   void clear() {
+-    cache_.clear();
++    // Detach entries before destroying them. CacheEntry destructors can
++    // transitively call compile_erase() — for example via the shared_ptr
++    // deleter wired up by the public compile(std::function) overload —
++    // which re-enters cache_.erase(). If we let cache_.clear() walk the
++    // live map, that reentrant erase reads __bucket_list_ pointers into
++    // nodes already deallocated by the in-progress walk (use-after-free).
++    // Moving first leaves cache_ empty, so reentrant erases hit an empty
++    // map and are no-ops while the detached map drains safely.
++    auto detached = std::move(cache_);
+   }
+ 
+   bool empty() {
+@@ -386,6 +394,14 @@ class CompilerCache {
+     allocator::allocator();
+   }
+ 
++  ~CompilerCache() {
++    // Drain via a detached map for the same reason as clear(). Without
++    // this, ~unordered_map at thread exit walks live entries whose
++    // destructors may re-enter cache_.erase(), hitting UAF on bucket
++    // pointers to already-freed nodes.
++    auto detached = std::move(cache_);
++  }
++
+   friend CompilerCache& compiler_cache();
+   std::unordered_map<std::uintptr_t, std::vector<CacheEntry>> cache_;
+ };


### PR DESCRIPTION
Two related changes around MLX's compiler cache:

1. **MLX patch** (`07-compiler-cache-detach-on-destroy.patch`) — fixes a use-after-free in `mlx::core::detail::CompilerCache` triggered at thread/process teardown.
2. **`MlxExecutable` cleanup** — switches from `mlx::core::detail::compile(fn, this)` + manual `compile_erase` in `~MlxExecutable` to the public `mlx::core::compile(fn)` API, which wires eviction through a `shared_ptr` deleter automatically.

## The bug

`CompilerCache` is a thread_local `std::unordered_map`. Cache entries hold `mlx::core::array` values whose primitive shared_ptrs may have deleters that call `compile_erase()` back into the same cache (e.g. closures returned by the public `compile(std::function)` overload, or hand-rolled equivalents like the `CacheGuard` in #142, or `~MlxExecutable` here).

At teardown, `~CompilerCache → ~unordered_map → __deallocate_node` walks the live linked list and destroys entries one-by-one. `__bucket_list_[i]` pointers are not nulled until *after* the whole walk completes. If an entry's destruction transitively triggers `cache_.erase(other_id)`, the reentrant `find` reads a `__bucket_list_[hash(other_id)]` pointer that already references a deallocated node — UAF.

## Reproduction

Running the upstream JAX test suite (`scripts/run_jax_tests.py`) with #142's `WhileLoopPrimitive` against unpatched MLX 0.31.2 reliably crashes around the 8% mark with EXC_BAD_ACCESS / SIGSEGV. Stack from `~/Library/Logs/DiagnosticReports/Python-2026-05-06-091955.ips`:

```
thread_start → _pthread_exit → tsd_cleanup
  → ThreadLocalVariables::finalizeList
  → ~CompilerCache
  → __hash_table::__deallocate_node
  → ~CacheEntry → ~array → ~WhileLoopPrimitive
  → ~CacheGuard (shared_ptr deleter)
  → compile_erase → __erase_unique  ← UAF read at non-canonical addr
```

This matches the stack reported in the discussion on #142 (originally referenced as #134's exit-time SIGSEGV).

## Fix (commit 1: MLX patch)

Detach entries before destroying them in both `clear()` and `~CompilerCache()`:

```cpp
void clear() {
    auto detached = std::move(cache_);   // cache_ now empty
}                                        // detached drains here

~CompilerCache() {
    auto detached = std::move(cache_);
}
```

While `detached` drains, any reentrant `cache_.erase(id)` from inside a value's destructor finds `cache_` empty and is a safe no-op. The detached map's `~unordered_map` still has the same internal walk, but reentrant erases now go to a *different* (empty) cache.

## Cleanup (commit 2: MlxExecutable)

`MlxExecutable` was using the internal `detail::compile(fn, this)` overload + a manual `compile_erase(this)` in its destructor. The public `mlx::core::compile(std::function)` overload wraps capturing closures in a `shared_ptr` whose custom deleter calls `compile_erase` when the returned `std::function` dies — eviction is tied to `compiled_fn_`'s lifetime automatically. Drops the explicit destructor body (now `= default`) and the `<mlx/compile_impl.h>` include. Functional behavior is unchanged.

This is independent of (and complementary to) the patch: the patch makes the cache safe under reentrant erase regardless of how callers register; the cleanup removes one of two consumers using the brittle internal API.

## Verification

| Config | Outcome |
|---|---|
| #142 (CacheGuard) + unpatched MLX | SIGSEGV at ~8% (#134 stack) |
| #142 + this patch | Full suite to completion, EXITCODE=0 |
| `MlxExecutable` cleanup commit | All 2114 ops tests pass |

Both JAX-suite runs used `scripts/run_jax_tests.py` with default settings.

## Notes

- The MLX patch is upstream-able; this is a stopgap until then.
- #142's `WhileLoopPrimitive` could also switch to the public `mlx::core::compile` API and drop its hand-rolled `CacheGuard`. That refactor is staged separately and will land via #142's branch.

## Test plan

- [x] Build MLX with patch applied (`bash scripts/setup_deps_mlx.sh`)
- [x] Build plugin (`uv pip install -e .`)
- [x] Run full upstream JAX suite (`uv run python scripts/run_jax_tests.py`) — exits cleanly
- [x] Run full ops test suite (`uv run pytest tests/test_ops.py`) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)