### PR TITLE
Fix scatter_prod GPU hang on NaN with contention

### DIFF
--- a/third_party/mlx/patches/08-scatter-mul-nan-fix.patch
+++ b/third_party/mlx/patches/08-scatter-mul-nan-fix.patch
@@ -1,0 +1,40 @@
+Cherry-picked from upstream MLX PR #3492:
+  https://github.com/ml-explore/mlx/pull/3492
+
+This is the exact upstream diff against v0.31.2; once #3492 lands and we
+bump our MLX pin past it, this patch should drop with zero churn.
+
+diff --git a/mlx/backend/metal/kernels/atomic.h b/mlx/backend/metal/kernels/atomic.h
+index 93952c2cf2..c55876137b 100644
+--- a/mlx/backend/metal/kernels/atomic.h
++++ b/mlx/backend/metal/kernels/atomic.h
+@@ -92,9 +92,29 @@ METAL_FUNC void mlx_atomic_fetch_mul_explicit(
+     device mlx_atomic<T>* object,
+     T val,
+     size_t offset) {
++  // Floating-point NaN handling: `nan * anything = nan` mathematically, but
++  // Metal's atomic_compare_exchange_weak does *bitwise* comparison. When NaN
++  // is involved, `val * expected` can produce a NaN bit pattern that differs
++  // from `expected`, so the CAS keeps failing and the loop spins forever.
++  // Short-circuit when NaN is in play — the result is well-defined (NaN), so
++  // we just store a NaN. Storing `val` / `expected` directly (rather than
++  // `val * expected`) avoids depending on Metal's NaN-payload behavior,
++  // which is exactly the mechanism the CAS spin depends on.
++  if constexpr (metal::is_floating_point_v<T>) {
++    if (isnan(val)) {
++      mlx_atomic_store_explicit(object, val, offset);
++      return;
++    }
++  }
+   T expected = mlx_atomic_load_explicit(object, offset);
+   while (!mlx_atomic_compare_exchange_weak_explicit(
+       object, &expected, val * expected, offset)) {
++    if constexpr (metal::is_floating_point_v<T>) {
++      if (isnan(expected)) {
++        mlx_atomic_store_explicit(object, expected, offset);
++        return;
++      }
++    }
+   }
+ }
+ 


### PR DESCRIPTION
## Summary

MLX's atomic-CAS multiply primitive spins forever on the GPU under a specific NaN+contention pattern, severe enough to wedge the macOS compositor and force a hard reboot. Adds a one-file MLX patch that short-circuits the CAS loop when NaN is in play.

This is a **cherry-pick of upstream MLX [PR #3492](https://github.com/ml-explore/mlx/pull/3492)**, applied verbatim against `v0.31.2`. Once that lands and we bump our MLX pin past it, this patch drops with zero diff churn.

## Reproduction (pre-fix)

```python
import jax, jax.numpy as jnp, numpy as np
x = jnp.array([1., 1., 1., 1.], dtype=jnp.float32)
indices = jnp.array([[0], [0]], dtype=jnp.int32)
updates = jnp.array([np.float32(np.nan), np.float32(2.0)])
out = jax.lax.scatter_mul(
    x, indices, updates,
    jax.lax.ScatterDimensionNumbers((), (0,), (0,)),
    unique_indices=False, indices_are_sorted=False,
)
jax.block_until_ready(out)   # never returns; GPU compositor freezes
```

In the wild this surfaced through `lax_numpy_indexing_test.py::testStaticIndexingGrads` during upstream-JAX test runs and showed up as the multi-hour pytest hang we'd been chasing in #142 / #146 follow-up.

## Root cause

`mlx_atomic_fetch_mul_explicit` in `mlx/backend/metal/kernels/atomic.h`:

```cpp
T expected = mlx_atomic_load_explicit(object, offset);
while (!mlx_atomic_compare_exchange_weak_explicit(
    object, &expected, val * expected, offset)) {}
```

Metal's `atomic_compare_exchange_weak_explicit` on float types does **bitwise** comparison. IEEE 754 leaves NaN payloads implementation-defined for arithmetic, and Apple Silicon's FP multiply can produce a NaN bit pattern that differs from `expected` even when `expected` is itself NaN. So `val * expected` keeps producing different NaN bits, the CAS keeps failing, the loop never converges.

Smoking-gun confirmation: same set of updates **reordered** so a non-NaN value lands first does not hang. The first thread CASes `1.0 → 2.0` (normal bits, succeeds); the second thread reloads `2.0`, computes `nan * 2.0 = nan_bits`, and CASes `2.0 → nan_bits` once (succeeds, no contention behind it).

## Why only float32

The non-native (`float16` / `bfloat16`) path packs sub-32-bit floats into a `uint32` and does **integer** atomic CAS. The bit pattern after `val * mem` is deterministic at the integer level — empirically, Apple Silicon's float16/bfloat16 multiply produces stable NaN bits — so the CAS converges. Verified: same NaN+contention case completes correctly on float16 and bfloat16 with no patch needed. Upstream's choice to skip those paths is empirically correct.

## Fix

`nan * x = nan` for any `x`, so the moment NaN appears the result is determined and the CAS retry is unnecessary. Short-circuit:

- If `val` is NaN at entry: `atomic_store(val)` and return.
- If `expected` becomes NaN inside the loop: `atomic_store(expected)` and return.

(Storing `val` / `expected` directly rather than `val * expected` avoids depending on Metal's NaN-payload behavior — exactly the mechanism the spin depends on.)

## Verification

16-case matrix exercised through JAX's `lax.scatter_mul` (which routes through patched MLX); all pass with correct semantics in <30s total. Including the most aggressive variants that wedged the compositor on unpatched MLX:

| Case | Updates | Indices | Pre-fix | Post-fix |
|---|---|---|---|---|
| `nan_normal_same` | `[nan, 2.0]` | `[[0],[0]]` | **HANG** | passes, out[0] = nan |
| `2nan_same` | `[nan, nan]` | `[[0],[0]]` | **HANG** | passes, out[0] = nan |
| `contend_nan` (1 NaN + 63 normals to pos 0) | | | **HANG** | passes |
| `snan` (64 sNaN to pos 0) | | | **HANG** | passes |
| `all_nan_contend` (64 NaN to pos 0) | | | **HANG** | passes |
| `normal_nan_same` (workaround) | `[2.0, nan]` | `[[0],[0]]` | passes | passes |
| `nan_normal_diff` | `[nan, 2.0]` | `[[0],[1]]` | passes | passes |
| `1nan_*` (single update) | `[nan]` | `[[0]]` | passes | passes |
| `2inf_same`, `*zero*` (other special FP values) | | | passes | passes |

Verified semantics match numpy: contended position absorbs the NaN.

## Notes

- Patch dir's stamp logic (`.mlx-tag` includes patch checksums) means the rebuild picks this up automatically.
- The bug forced a hard reboot **twice** during investigation — please be aware when running unfixed MLX manually.

## Test plan

- [x] Build MLX with patch applied (`bash scripts/setup_deps_mlx.sh`)
- [x] Build plugin (`uv pip install -e .`)
- [x] Run 16-case matrix — all complete with correct output
- [x] Verify float32 / float16 / bfloat16 — all complete (only f32 needed the patch)
- [ ] Run full upstream JAX suite once to confirm no regression and no recurrence of the testStaticIndexingGrads hang

🤖 Generated with [Claude Code](https://claude.com/claude-code)