### PR TITLE
Support wide SVD (M < N) by reducing to the tall case

### DIFF
--- a/src/jax_plugins/mps/ops.py
+++ b/src/jax_plugins/mps/ops.py
@@ -600,6 +600,25 @@ def _qr_lowering(ctx, operand, *, full_matrices, **kwargs):
     ).results
 
 
+def _svd_via_transpose(operand, *, full_matrices, compute_uv):
+    """Compute SVD of a wide matrix (M < N) by reducing to the tall case.
+
+    For A with shape (..., M, N) and M < N:  A = (Aᵀ)ᵀ = (Û Σ V̂ᵀ)ᵀ = V̂ Σ Ûᵀ,
+    where Û Σ V̂ᵀ is the SVD of Aᵀ. So U = V̂ = (V̂ᵀ)ᵀ, Vᵀ = Ûᵀ.
+    """
+    operand_t = jnp.swapaxes(operand, -1, -2)
+    if compute_uv:
+        u_hat, s, vt_hat = lax_linalg.svd(
+            operand_t, full_matrices=full_matrices, compute_uv=True
+        )
+        u = jnp.swapaxes(vt_hat, -1, -2)
+        vt = jnp.swapaxes(u_hat, -1, -2)
+        # svd_p abstract eval order is (s, u, vt) — match that here so
+        # mlir.lower_fun lines up the results with ctx.avals_out.
+        return s, u, vt
+    return lax_linalg.svd(operand_t, full_matrices=full_matrices, compute_uv=False)
+
+
 def _svd_lowering(
     ctx, operand, *, full_matrices, compute_uv, subset_by_index, algorithm
 ):
@@ -611,10 +630,15 @@ def _svd_lowering(
     operand_aval = ctx.avals_in[0]
     m, n = operand_aval.shape[-2], operand_aval.shape[-1]
     if m < n:
-        raise NotImplementedError(
-            f"MPS SVD does not yet support wide matrices (M < N). "
-            f"Got {m}×{n}. Transpose the input first."
-        )
+        # MPS SVD kernel only handles tall matrices (M >= N). Reduce to the
+        # tall case by transposing; the recursive lax_linalg.svd call lowers
+        # again through this rule with the dimensions swapped.
+        return mlir.lower_fun(
+            lambda x: _svd_via_transpose(
+                x, full_matrices=full_matrices, compute_uv=compute_uv
+            ),
+            multiple_results=compute_uv,
+        )(ctx, operand)
     fm = "true" if full_matrices else "false"
     if compute_uv:
         # JAX svd_p abstract eval returns (s, u, vt) – note s first!

--- a/tests/configs/linalg.py
+++ b/tests/configs/linalg.py
@@ -323,16 +323,23 @@ def make_linalg_op_configs():
             lambda key: random.normal(key, (4, 2)),
             name="svd_values_4x2",
         )
-        # Wide SVD (M < N) rejected at lowering (github.com/tillahoffmann/jax-mps#119)
-        yield pytest.param(
-            OperationTestConfig(
-                _svd_values,
-                lambda key: random.normal(key, (2, 4)),
-                name="svd_values_2x4",
-            ),
-            marks=[
-                xfail_match("does not yet support wide matrices|not yet support wide")
-            ],
+        # Wide SVD (M < N) — handled by transposing the operand and
+        # remapping outputs.
+        yield OperationTestConfig(
+            _svd_values,
+            lambda key: random.normal(key, (2, 4)),
+            name="svd_values_2x4",
+        )
+        yield OperationTestConfig(
+            _svd_reconstruct,
+            lambda key: random.normal(key, (2, 4)),
+            name="svd_reconstruct_2x4",
+        )
+        yield OperationTestConfig(
+            _svd_reconstruct_full,
+            lambda key: random.normal(key, (2, 4)),
+            name="svd_reconstruct_full_2x4",
+            grad_xfail="Singular value decomposition JVP not implemented for full matrices",
         )
 
         # Batched SVD
@@ -558,17 +565,11 @@ def make_linalg_op_configs():
             marks=[_xfail_large],
         )
 
-        # Wide SVD (M < N) rejected at lowering time (github.com/tillahoffmann/jax-mps#119)
-        _xfail_wide_svd = xfail_match(
-            "does not yet support wide matrices|not yet support wide"
-        )
-        yield pytest.param(
-            OperationTestConfig(
-                _svd_values,
-                lambda key: random.normal(key, (4, 8)),
-                name="svd_values_4x8_wide",
-            ),
-            marks=[_xfail_wide_svd],
+        # Wide SVD (M < N) — handled by transposing the operand.
+        yield OperationTestConfig(
+            _svd_values,
+            lambda key: random.normal(key, (4, 8)),
+            name="svd_values_4x8_wide",
         )
 
         # --- LU Decomposition ---


### PR DESCRIPTION
## Summary

- Previously `_svd_lowering` raised `NotImplementedError` whenever `M < N`, since the underlying `mps.svd` kernel only handles tall inputs.
- Lift the restriction by transposing the operand to `(N, M)`, recursing through `lax_linalg.svd` (which re-enters this same lowering with the dimensions swapped), and remapping the outputs:

  Aᵀ = Û Σ V̂ᵀ  ⟹  A = V̂ Σ Ûᵀ ⟹ U = (V̂ᵀ)ᵀ, Vᵀ = Ûᵀ, Σ unchanged.
- Replace the wide-SVD xfails in the linalg test config with positive tests covering values, reduced reconstruction, and full reconstruction.
- Refs #119.

Net upstream impact (jax 0.10.0 test suite): **+16 tests now passing** (`svd_test` +3, `qdwh_test` +13). `lobpcg_test` still blocked, this time on eigh `complex64`.

## Test plan

- [x] `uv run pytest tests/test_ops.py -k svd` — 76 passed, 8 xfailed (large/full-rect grad limits, unrelated).
- [x] `uv run pytest` (full local suite) — 2147 passed, 232 skipped, 32 xfailed; no regressions.
- [x] Spot-check upstream `svd_test.py`, `qdwh_test.py`: gains confirmed; remaining failures are complex64 paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)