### PR TITLE
Bridge StableHLO conv semantics for lhs_dilation + negative padding

### DIFF
--- a/src/pjrt_plugin/ops/linalg.cc
+++ b/src/pjrt_plugin/ops/linalg.cc
@@ -387,6 +387,31 @@ bool HandleConvolution(mlir::Operation* op, ValueMap& values,
     if (useWeightGradVJP) {
         convResult = vjpResult;
     } else {
+        // StableHLO conv semantics dilate the LHS first, then apply padding.
+        // MLX's conv_general slices the input for negative padding before
+        // applying input_dilation (mlx/ops.cpp:conv_general). The two orders
+        // agree everywhere except on axes where input_dilation > 1 and the
+        // padding is negative; on those axes, materialize the dilated input
+        // here and pass input_dilation=1 so MLX applies the negative padding
+        // to the already-dilated tensor.
+        for (int i = 0; i < numSpatialDims; ++i) {
+            if (inputDilation[i] <= 1)
+                continue;
+            if (paddingLow[i] >= 0 && paddingHigh[i] >= 0)
+                continue;
+            int axis = 1 + i;  // inputT layout is [N, spatial..., C_in].
+            int L = inputT.shape(axis);
+            if (L <= 0)
+                continue;
+            auto dilatedShape = inputT.shape();
+            dilatedShape[axis] = (L - 1) * inputDilation[i] + 1;
+            mlx::core::Shape starts(inputT.ndim(), 0);
+            mlx::core::Shape striding(inputT.ndim(), 1);
+            striding[axis] = inputDilation[i];
+            auto zeros = mlx::core::zeros(dilatedShape, inputT.dtype());
+            inputT = mlx::core::slice_update(zeros, inputT, starts, dilatedShape, striding);
+            inputDilation[i] = 1;
+        }
         convResult =
             mlx::core::conv_general(inputT, kernelT, strides, paddingLow, paddingHigh,
                                     kernelDilation, inputDilation, featureGroupCount, false);

--- a/tests/configs/conv.py
+++ b/tests/configs/conv.py
@@ -121,6 +121,38 @@ def make_conv_op_configs():
                 lambda key: random.uniform(key, (3, 3, 4), minval=-1.0, maxval=1.0),
                 name="lax.conv_general_dilated-1d-stride2-dilated",
             ),
+            # lhs_dilation + negative padding on the same axis.
+            # StableHLO semantics dilate first then pad; MLX's conv slices for
+            # negative padding before applying input_dilation, so the two
+            # conventions diverge here. The handler must bridge them.
+            OperationTestConfig(
+                lambda x, kernel: lax.conv_general_dilated(
+                    x,
+                    kernel,
+                    window_strides=(1, 1),
+                    padding=((0, -1), (0, 0)),
+                    lhs_dilation=(2, 1),
+                    dimension_numbers=("NHWC", "HWIO", "NHWC"),
+                ),
+                lambda key: random.uniform(key, (1, 6, 7, 4), minval=-1.0, maxval=1.0),
+                lambda key: random.uniform(key, (1, 2, 4, 2), minval=-1.0, maxval=1.0),
+                name="lax.conv_general_dilated-lhs_dilation-neg_padding",
+            ),
+            # lhs_dilation alone (no negative padding) should already work and
+            # serves as a regression guard for the bridging code.
+            OperationTestConfig(
+                lambda x, kernel: lax.conv_general_dilated(
+                    x,
+                    kernel,
+                    window_strides=(1, 1),
+                    padding=((0, 0), (0, 0)),
+                    lhs_dilation=(2, 1),
+                    dimension_numbers=("NHWC", "HWIO", "NHWC"),
+                ),
+                lambda key: random.uniform(key, (1, 6, 7, 4), minval=-1.0, maxval=1.0),
+                lambda key: random.uniform(key, (1, 2, 4, 2), minval=-1.0, maxval=1.0),
+                name="lax.conv_general_dilated-lhs_dilation-only",
+            ),
             # Large-kernel conv where kernel_size >= input_size with SAME padding.
             # This can false-positive match the weight-gradient VJP heuristic
             # (kH >= 2*out_H) since the output is small relative to the kernel.


### PR DESCRIPTION
## Summary

- StableHLO conv mandates **dilate-then-pad**: the LHS is dilated by \`lhs_dilation\` first, then padding is applied. MLX's \`conv_general\` (\`mlx/ops.cpp\`) slices the input for negative padding *before* applying \`input_dilation\`, so the two orders agree everywhere except on axes where \`input_dilation > 1\` and the padding is negative — exactly the case JAX's \`vmap\` stress tests exercise.
- When that combination is detected on a spatial axis, materialize the dilated input ourselves via \`slice_update\` into a zeros buffer and pass \`input_dilation=1\` to MLX so it applies the negative padding to the already-dilated tensor.
- The pre-dilation lives inside the \`else\` branch of the \`useWeightGradVJP\` heuristic, so the heuristic still gates on the original \`input_dilation\` (and is unreachable from this code path since it requires \`input_dilation == 1\` on both axes).

## Test plan

- [x] New regression tests in \`tests/configs/conv.py\`:
  - \`lax.conv_general_dilated-lhs_dilation-neg_padding\` exercises the divergent path.
  - \`lax.conv_general_dilated-lhs_dilation-only\` guards the non-divergent case.
- [x] \`uv run pytest tests/test_ops.py -k conv\` — 86 passed, 6 skipped.
- [x] \`uv run pytest\` (full local suite) — 2155 passed, 232 skipped, 32 xfailed; no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)