### PR TITLE
perf(top_k): use argpartition instead of full argsort

### DIFF
--- a/src/pjrt_plugin/ops/sort_fft_complex.cc
+++ b/src/pjrt_plugin/ops/sort_fft_complex.cc
@@ -46,9 +46,19 @@ std::pair<mlx::core::array, mlx::core::array> TopKImplFn(const mlx::core::array&
     auto input = mlx::core::contiguous(input_);
     int axis = static_cast<int>(input.ndim()) - 1;
     int axisSize = input.shape(axis);
+
+    // k == 1: argmax is the cheapest path and preserves lowest-original-index ties.
+    if (k == 1) {
+        auto indices = mlx::core::argmax(input, axis, /*keepdims=*/true);
+        auto topValues = mlx::core::take_along_axis(input, indices, axis);
+        return {topValues, mlx::core::astype(indices, mlx::core::int32)};
+    }
+
     auto key = DescendingKey(input);
 
-    mlx::core::array partitionedIndices = (k > 0 && k < axisSize)
+    // k >= axisSize (or k == 0): argpartition rejects kth >= axis_size, fall back to
+    // a full argsort. argsort is stable so ties resolve to ascending original index.
+    mlx::core::array partitionedIndices = (k > 1 && k < axisSize)
                                               ? mlx::core::argpartition(key, k - 1, axis)
                                               : mlx::core::argsort(key, axis);
 

--- a/src/pjrt_plugin/ops/sort_fft_complex.cc
+++ b/src/pjrt_plugin/ops/sort_fft_complex.cc
@@ -36,22 +36,40 @@ mlx::core::array DescendingKey(const mlx::core::array& input) {
 }
 
 // Compute top-k values and indices along the last axis.
-// Uses a descending sort key + ascending argsort + take-first-k to preserve stable
-// tie ordering (equal values keep lowest-index-first).
+//
+// Uses argpartition (O(n) partial sort) to isolate the k smallest descending-key
+// elements, then a stable argsort restricted to those k entries to emit them in
+// descending-by-value order with ties broken by ascending original index. This
+// is asymptotically faster than a full argsort+slice when k << axis size while
+// preserving the same tie semantics callers rely on.
 std::pair<mlx::core::array, mlx::core::array> TopKImplFn(const mlx::core::array& input_, int k) {
-    // argsort requires contiguous input; handle it here so callers don't have to.
     auto input = mlx::core::contiguous(input_);
     int axis = static_cast<int>(input.ndim()) - 1;
+    int axisSize = input.shape(axis);
     auto key = DescendingKey(input);
-    auto allIndices = mlx::core::argsort(key, axis);
 
-    mlx::core::Shape starts(allIndices.ndim(), 0);
-    mlx::core::Shape stops(allIndices.shape().begin(), allIndices.shape().end());
+    mlx::core::array partitionedIndices = (k > 0 && k < axisSize)
+                                              ? mlx::core::argpartition(key, k - 1, axis)
+                                              : mlx::core::argsort(key, axis);
+
+    mlx::core::Shape starts(partitionedIndices.ndim(), 0);
+    mlx::core::Shape stops(partitionedIndices.shape().begin(), partitionedIndices.shape().end());
     stops[axis] = k;
-    auto indices = mlx::core::slice(allIndices, starts, stops);
+    partitionedIndices = mlx::core::slice(partitionedIndices, starts, stops);
 
-    auto topValues = mlx::core::take_along_axis(input, indices, axis);
-    return {topValues, mlx::core::astype(indices, mlx::core::int32)};
+    if (k > 1 && k < axisSize) {
+        // argpartition does not guarantee stable order within the selected slot, so
+        // re-sort the k chosen indices by key. The stable argsort breaks ties by the
+        // current index position; pre-sorting the partitioned indices ascending lines
+        // those positions up with ascending original indices.
+        partitionedIndices = mlx::core::sort(partitionedIndices, axis);
+        auto partitionedKeys = mlx::core::take_along_axis(key, partitionedIndices, axis);
+        auto order = mlx::core::argsort(partitionedKeys, axis);
+        partitionedIndices = mlx::core::take_along_axis(partitionedIndices, order, axis);
+    }
+
+    auto topValues = mlx::core::take_along_axis(input, partitionedIndices, axis);
+    return {topValues, mlx::core::astype(partitionedIndices, mlx::core::int32)};
 }
 
 // Analyze a sort comparator to determine sort direction.

--- a/tests/configs/sort.py
+++ b/tests/configs/sort.py
@@ -393,6 +393,16 @@ def make_sort_op_configs():
             )
         )
 
+        # top_k k=1 with ties: exercises the argmax fast path, must return
+        # the lowest original index among tied maxima.
+        configs.append(
+            OperationTestConfig(
+                lambda x: lax.top_k(x, 1),
+                jnp.array([3.0, 1.0, 3.0, 2.0, 3.0]),
+                name="lax.top_k.ties.k1",
+            )
+        )
+
         # top_k with integer input (exercises bitwise-NOT descending key)
         configs.append(
             OperationTestConfig(


### PR DESCRIPTION
## Summary
- `TopKImplFn` swapped from full `argsort` + slice (O(n log n)) to `argpartition` + restricted stable argsort over the k chosen indices.
- `mlx::core::topk` itself was unsuitable as a drop-in: it returns values only, is internally an unsorted partition + slice, and so couldn't satisfy our (values, indices, descending order) contract without extra work. `argpartition` is the underlying primitive and gives the partial-sort win directly.
- Tie semantics ("equal values keep lowest-original-index first") preserved by pre-sorting the partitioned k indices ascending before the stable argsort, so equal keys resolve in ascending-original-index order.
- Edge cases (`k == 0`, `k == axisSize`) fall back to `argsort` since `argpartition` rejects `kth >= axis_size`.

Closes #131

## Test plan
- [x] `uv run pytest tests/test_ops.py -k "sort"` — 128 passed, 40 skipped
- [x] Tie-ordering tests (`lax.top_k.ties`, `lax.top_k.int32`) green
- [x] pre-commit (clang-format, clang-tidy, pyright, build, pytest) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)