### PR TITLE
ci: bump runners to macos-26 and patch out MLX's jaccl backend

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
   # no longer forces an LLVM rebuild (~1h).
   setup-llvm:
     name: Setup LLVM/StableHLO
-    runs-on: macos-14
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v6
 
@@ -45,7 +45,7 @@ jobs:
 
   setup-protobuf:
     name: Setup Protobuf
-    runs-on: macos-14
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v6
 
@@ -76,7 +76,7 @@ jobs:
 
   setup-mlx:
     name: Setup MLX
-    runs-on: macos-14
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v6
 
@@ -108,7 +108,7 @@ jobs:
   build:
     name: Build wheel
     needs: [setup-llvm, setup-protobuf, setup-mlx]
-    runs-on: macos-14
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v6
 
@@ -155,7 +155,7 @@ jobs:
   lint-cpp:
     name: Lint C++
     needs: [setup-llvm, setup-protobuf, setup-mlx]
-    runs-on: macos-14
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v6
 
@@ -206,7 +206,7 @@ jobs:
   lint-python:
     name: Lint Python
     needs: build
-    runs-on: macos-14
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v6
 
@@ -238,7 +238,7 @@ jobs:
   build-dev:
     name: Build dev wheel
     needs: [setup-llvm, setup-protobuf, setup-mlx]
-    runs-on: macos-14
+    runs-on: macos-26
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     steps:
       - uses: actions/checkout@v6
@@ -288,7 +288,7 @@ jobs:
   test:
     name: Test
     needs: build
-    runs-on: macos-14
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,12 @@ on:
     branches: [main]
   workflow_dispatch:
 
+env:
+  # Used in cache keys so caches don't cross runner OSes. NOT usable in
+  # `runs-on:` — the `env` context is not available there (GitHub Actions
+  # limitation). Keep this in sync with the literal `runs-on:` values below.
+  RUNNER_IMAGE: macos-26
+
 jobs:
   # Three parallel dependency builds with independent caches.
   # Each cache key hashes only the relevant script(s), so bumping MLX
@@ -23,7 +29,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ${{ github.workspace }}/.jax-mps-deps/llvm
-          key: deps-llvm-v1-macos14-${{ hashFiles('scripts/setup_deps_common.sh', 'scripts/setup_deps_llvm.sh') }}
+          key: deps-llvm-v1-${{ env.RUNNER_IMAGE }}-${{ hashFiles('scripts/setup_deps_common.sh', 'scripts/setup_deps_llvm.sh') }}
           lookup-only: true
 
       - name: Install build tools
@@ -41,7 +47,7 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: ${{ github.workspace }}/.jax-mps-deps/llvm
-          key: deps-llvm-v1-macos14-${{ hashFiles('scripts/setup_deps_common.sh', 'scripts/setup_deps_llvm.sh') }}
+          key: deps-llvm-v1-${{ env.RUNNER_IMAGE }}-${{ hashFiles('scripts/setup_deps_common.sh', 'scripts/setup_deps_llvm.sh') }}
 
   setup-protobuf:
     name: Setup Protobuf
@@ -54,7 +60,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ${{ github.workspace }}/.jax-mps-deps/protobuf
-          key: deps-protobuf-v1-macos14-${{ hashFiles('scripts/setup_deps_common.sh', 'scripts/setup_deps_protobuf.sh') }}
+          key: deps-protobuf-v1-${{ env.RUNNER_IMAGE }}-${{ hashFiles('scripts/setup_deps_common.sh', 'scripts/setup_deps_protobuf.sh') }}
           lookup-only: true
 
       - name: Install build tools
@@ -72,7 +78,7 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: ${{ github.workspace }}/.jax-mps-deps/protobuf
-          key: deps-protobuf-v1-macos14-${{ hashFiles('scripts/setup_deps_common.sh', 'scripts/setup_deps_protobuf.sh') }}
+          key: deps-protobuf-v1-${{ env.RUNNER_IMAGE }}-${{ hashFiles('scripts/setup_deps_common.sh', 'scripts/setup_deps_protobuf.sh') }}
 
   setup-mlx:
     name: Setup MLX
@@ -85,7 +91,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ${{ github.workspace }}/.jax-mps-deps/mlx
-          key: deps-mlx-v1-macos14-${{ hashFiles('scripts/setup_deps_common.sh', 'scripts/setup_deps_mlx.sh', 'third_party/mlx/version.txt', 'third_party/mlx/patches/*') }}
+          key: deps-mlx-v1-${{ env.RUNNER_IMAGE }}-${{ hashFiles('scripts/setup_deps_common.sh', 'scripts/setup_deps_mlx.sh', 'third_party/mlx/version.txt', 'third_party/mlx/patches/*') }}
           lookup-only: true
 
       - name: Install build tools
@@ -103,7 +109,7 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: ${{ github.workspace }}/.jax-mps-deps/mlx
-          key: deps-mlx-v1-macos14-${{ hashFiles('scripts/setup_deps_common.sh', 'scripts/setup_deps_mlx.sh', 'third_party/mlx/version.txt', 'third_party/mlx/patches/*') }}
+          key: deps-mlx-v1-${{ env.RUNNER_IMAGE }}-${{ hashFiles('scripts/setup_deps_common.sh', 'scripts/setup_deps_mlx.sh', 'third_party/mlx/version.txt', 'third_party/mlx/patches/*') }}
 
   build:
     name: Build wheel
@@ -121,21 +127,21 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ${{ github.workspace }}/.jax-mps-deps/llvm
-          key: deps-llvm-v1-macos14-${{ hashFiles('scripts/setup_deps_common.sh', 'scripts/setup_deps_llvm.sh') }}
+          key: deps-llvm-v1-${{ env.RUNNER_IMAGE }}-${{ hashFiles('scripts/setup_deps_common.sh', 'scripts/setup_deps_llvm.sh') }}
           fail-on-cache-miss: true
 
       - name: Restore Protobuf cache
         uses: actions/cache/restore@v5
         with:
           path: ${{ github.workspace }}/.jax-mps-deps/protobuf
-          key: deps-protobuf-v1-macos14-${{ hashFiles('scripts/setup_deps_common.sh', 'scripts/setup_deps_protobuf.sh') }}
+          key: deps-protobuf-v1-${{ env.RUNNER_IMAGE }}-${{ hashFiles('scripts/setup_deps_common.sh', 'scripts/setup_deps_protobuf.sh') }}
           fail-on-cache-miss: true
 
       - name: Restore MLX cache
         uses: actions/cache/restore@v5
         with:
           path: ${{ github.workspace }}/.jax-mps-deps/mlx
-          key: deps-mlx-v1-macos14-${{ hashFiles('scripts/setup_deps_common.sh', 'scripts/setup_deps_mlx.sh', 'third_party/mlx/version.txt', 'third_party/mlx/patches/*') }}
+          key: deps-mlx-v1-${{ env.RUNNER_IMAGE }}-${{ hashFiles('scripts/setup_deps_common.sh', 'scripts/setup_deps_mlx.sh', 'third_party/mlx/version.txt', 'third_party/mlx/patches/*') }}
           fail-on-cache-miss: true
 
       - name: Install dependencies
@@ -168,21 +174,21 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ${{ github.workspace }}/.jax-mps-deps/llvm
-          key: deps-llvm-v1-macos14-${{ hashFiles('scripts/setup_deps_common.sh', 'scripts/setup_deps_llvm.sh') }}
+          key: deps-llvm-v1-${{ env.RUNNER_IMAGE }}-${{ hashFiles('scripts/setup_deps_common.sh', 'scripts/setup_deps_llvm.sh') }}
           fail-on-cache-miss: true
 
       - name: Restore Protobuf cache
         uses: actions/cache/restore@v5
         with:
           path: ${{ github.workspace }}/.jax-mps-deps/protobuf
-          key: deps-protobuf-v1-macos14-${{ hashFiles('scripts/setup_deps_common.sh', 'scripts/setup_deps_protobuf.sh') }}
+          key: deps-protobuf-v1-${{ env.RUNNER_IMAGE }}-${{ hashFiles('scripts/setup_deps_common.sh', 'scripts/setup_deps_protobuf.sh') }}
           fail-on-cache-miss: true
 
       - name: Restore MLX cache
         uses: actions/cache/restore@v5
         with:
           path: ${{ github.workspace }}/.jax-mps-deps/mlx
-          key: deps-mlx-v1-macos14-${{ hashFiles('scripts/setup_deps_common.sh', 'scripts/setup_deps_mlx.sh', 'third_party/mlx/version.txt', 'third_party/mlx/patches/*') }}
+          key: deps-mlx-v1-${{ env.RUNNER_IMAGE }}-${{ hashFiles('scripts/setup_deps_common.sh', 'scripts/setup_deps_mlx.sh', 'third_party/mlx/version.txt', 'third_party/mlx/patches/*') }}
           fail-on-cache-miss: true
 
       - name: Install llvm
@@ -252,21 +258,21 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ${{ github.workspace }}/.jax-mps-deps/llvm
-          key: deps-llvm-v1-macos14-${{ hashFiles('scripts/setup_deps_common.sh', 'scripts/setup_deps_llvm.sh') }}
+          key: deps-llvm-v1-${{ env.RUNNER_IMAGE }}-${{ hashFiles('scripts/setup_deps_common.sh', 'scripts/setup_deps_llvm.sh') }}
           fail-on-cache-miss: true
 
       - name: Restore Protobuf cache
         uses: actions/cache/restore@v5
         with:
           path: ${{ github.workspace }}/.jax-mps-deps/protobuf
-          key: deps-protobuf-v1-macos14-${{ hashFiles('scripts/setup_deps_common.sh', 'scripts/setup_deps_protobuf.sh') }}
+          key: deps-protobuf-v1-${{ env.RUNNER_IMAGE }}-${{ hashFiles('scripts/setup_deps_common.sh', 'scripts/setup_deps_protobuf.sh') }}
           fail-on-cache-miss: true
 
       - name: Restore MLX cache
         uses: actions/cache/restore@v5
         with:
           path: ${{ github.workspace }}/.jax-mps-deps/mlx
-          key: deps-mlx-v1-macos14-${{ hashFiles('scripts/setup_deps_common.sh', 'scripts/setup_deps_mlx.sh', 'third_party/mlx/version.txt', 'third_party/mlx/patches/*') }}
+          key: deps-mlx-v1-${{ env.RUNNER_IMAGE }}-${{ hashFiles('scripts/setup_deps_common.sh', 'scripts/setup_deps_mlx.sh', 'third_party/mlx/version.txt', 'third_party/mlx/patches/*') }}
           fail-on-cache-miss: true
 
       - name: Build dev wheel

--- a/third_party/mlx/patches/09-disable-jaccl.patch
+++ b/third_party/mlx/patches/09-disable-jaccl.patch
@@ -1,0 +1,26 @@
+Disable MLX's jaccl (Thunderbolt-RDMA collective comms) backend on macOS
+SDK >= 26.2. We only use single-device MPS, so the distributed code path
+is dead weight. More importantly, MLX's CMake config exports
+`jaccl::jaccl` as an IMPORTED target in `MLXTargets.cmake` but installs
+no `jacclConfig.cmake`, so downstream `find_package(MLX)` fails when the
+jaccl branch is taken (SDK >= 26.2).
+
+Forcing `no_jaccl.cpp` makes the build behavior identical across SDK
+versions and avoids a fragile downstream CMake shim. Drop this patch
+when MLX exposes a `MLX_BUILD_DISTRIBUTED=OFF` option (or equivalent) or
+ships a proper jacclConfig.cmake.
+
+diff --git a/mlx/distributed/jaccl/CMakeLists.txt b/mlx/distributed/jaccl/CMakeLists.txt
+index 0000000..0000000 100644
+--- a/mlx/distributed/jaccl/CMakeLists.txt
++++ b/mlx/distributed/jaccl/CMakeLists.txt
+@@ -1,8 +1 @@
+-if(MLX_BUILD_CPU
+-   AND ${CMAKE_SYSTEM_NAME} MATCHES "Darwin"
+-   AND MACOS_SDK_VERSION GREATER_EQUAL 26.2)
+-  target_sources(mlx PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/jaccl.cpp)
+-  target_link_libraries(mlx PRIVATE jaccl)
+-else()
+-  target_sources(mlx PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/no_jaccl.cpp)
+-endif()
++target_sources(mlx PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/no_jaccl.cpp)


### PR DESCRIPTION
## Summary
- Bump `runs-on:` from `macos-14` to `macos-26` across all jobs in `build.yml`. macos-14's SDK 14.x silently hid a real downstream-build problem; macos-26 (default Xcode 26.2, SDK 26.4) exercises the full MLX configuration.
- Thread the runner image through a workflow-level `RUNNER_IMAGE` env var, used in cache keys so caches don't cross runner OSes. (Note: GitHub Actions does not allow `env` in `runs-on:`, so the literal `macos-26` still appears at each job — comment in the workflow flags this.)
- Add `third_party/mlx/patches/09-disable-jaccl.patch` to force MLX's `no_jaccl.cpp` branch on all SDKs.

## Why the jaccl patch
On SDK ≥ 26.2, MLX v0.31.2 unconditionally adds `target_link_libraries(mlx PRIVATE jaccl)` and propagates `jaccl::jaccl` as an IMPORTED target in `MLXTargets.cmake`, but installs no `jacclConfig.cmake`. Downstream `find_package(MLX)` then fails:

```
CMake Error at .jax-mps-deps/mlx/share/cmake/MLX/MLXTargets.cmake:61 (set_target_properties):
    jaccl::jaccl
    * A find_package call is missing for an IMPORTED target.
  CMakeLists.txt:110 (find_package)
```

This plugin is single-device PJRT for one Apple Silicon machine; JAX's collective ops sit below us in the stack, not above, so MLX's distributed backend is dead weight architecturally. Forcing `no_jaccl.cpp` makes every SDK take the same MLX code path, eliminating an SDK-version-dependent build divergence we'd otherwise have to chase.

## Test plan
- [x] `Build wheel`, `Lint C++`, `Lint Python`, `Test` all green on `macos-26` with the patch.
- [x] Confirmed the failure mode by running CI *without* the patch first (run 25709211990) — exact `MLXTargets.cmake` error above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)