### PR TITLE
Surface MLX/handler errors and skip f64 in upstream JAX suite

### DIFF
--- a/scripts/_pytest_skip_unsupported_plugin.py
+++ b/scripts/_pytest_skip_unsupported_plugin.py
@@ -44,13 +44,10 @@ def pytest_runtest_makereport(item, call):
     if report.when != "call" or not report.failed:
         return
 
-    haystack_parts = []
-    if report.longrepr is not None:
-        haystack_parts.append(str(report.longrepr))
-    for _, content in report.sections:
-        if content:
-            haystack_parts.append(content)
-    haystack = "\n".join(haystack_parts)
+    # Match only against the failure traceback/exception text, NOT captured
+    # stdout/stderr sections. An unrelated test that logged a float64 message
+    # earlier and then failed for some other reason must NOT be skipped.
+    haystack = str(report.longrepr) if report.longrepr is not None else ""
 
     if _matches_f64_rejection(haystack):
         report.outcome = "skipped"

--- a/scripts/_pytest_skip_unsupported_plugin.py
+++ b/scripts/_pytest_skip_unsupported_plugin.py
@@ -1,0 +1,59 @@
+"""Pytest plugin: convert genuine F64 buffer-creation failures into skips.
+
+MLX fundamentally does not support float64 on Metal. The PJRT plugin throws
+at buffer-creation time (PjrtDtypeToMlx in mlx_buffer.cc) with the message
+"MLX does not support float64 (F64)". That's the only signature that
+reliably indicates a test relies on float64; anything else (e.g. MLX's
+"Only float32 is supported on Metal" linalg rejection) also fires for
+complex64 / float16 / bfloat16 and would mask fixable bugs.
+
+Scope is deliberately narrow: only the F64 buffer-creation message is
+converted to skipped. All other failures (complex64, int conv, missing
+handlers, Metal size limits, etc.) remain failures.
+
+Enable by passing ``-p _pytest_skip_unsupported_plugin``. The
+``scripts/run_jax_tests.py`` runner does this automatically.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+# Match the exact message raised by PjrtDtypeToMlx for F64 buffers. Kept
+# specific so we never silently skip a complex64 / fp16 / bf16 failure that
+# happens to share MLX's generic "Only float32" wording.
+_F64_PATTERNS = [
+    re.compile(r"MLX does not support float64"),
+]
+
+_SKIP_REASON = "MLX does not support float64 on Metal"
+
+
+def _matches_f64_rejection(text: str) -> bool:
+    if not text:
+        return False
+    return any(p.search(text) for p in _F64_PATTERNS)
+
+
+@pytest.hookimpl(hookwrapper=True, trylast=True)
+def pytest_runtest_makereport(item, call):
+    outcome = yield
+    report = outcome.get_result()
+    if report.when != "call" or not report.failed:
+        return
+
+    haystack_parts = []
+    if report.longrepr is not None:
+        haystack_parts.append(str(report.longrepr))
+    for _, content in report.sections:
+        if content:
+            haystack_parts.append(content)
+    haystack = "\n".join(haystack_parts)
+
+    if _matches_f64_rejection(haystack):
+        report.outcome = "skipped"
+        # pytest renders skipped with longrepr as a (path, lineno, reason)
+        # tuple; reuse the test's location.
+        report.longrepr = (str(item.fspath), 0, f"Skipped: {_SKIP_REASON}")

--- a/scripts/run_jax_tests.py
+++ b/scripts/run_jax_tests.py
@@ -203,6 +203,8 @@ def main():
         "no:faulthandler",
         "-p",
         "no:benchmark",
+        "-p",
+        "_pytest_skip_unsupported_plugin",
         "--tb=no",
         "-q",
         f"--timeout={args.timeout}",
@@ -225,12 +227,12 @@ def main():
             "JAX_MPS_CACHE_LIMIT_BYTES", str(1 << 30)
         ),
     }
-    if args.memory_csv or args.current_test_file:
-        # Make the local plugin importable from the scripts/ directory.
-        scripts_dir = str(Path(__file__).resolve().parent)
-        env["PYTHONPATH"] = (
-            scripts_dir + os.pathsep + env.get("PYTHONPATH", "")
-        ).rstrip(os.pathsep)
+    # Make scripts/ plugins (_pytest_skip_unsupported_plugin and the optional
+    # _pytest_memory_plugin) importable.
+    scripts_dir = str(Path(__file__).resolve().parent)
+    env["PYTHONPATH"] = (scripts_dir + os.pathsep + env.get("PYTHONPATH", "")).rstrip(
+        os.pathsep
+    )
     print(f"\nRunning: pytest {tests_dir} ...\n")
     subprocess.run(cmd, cwd=project_root, env=env)
 

--- a/src/pjrt_plugin/mlx_executable.cc
+++ b/src/pjrt_plugin/mlx_executable.cc
@@ -13,6 +13,7 @@
 #include <stdexcept>
 #include <unordered_map>
 
+#include "llvm/Support/raw_ostream.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -333,6 +334,34 @@ const std::unordered_map<std::string, OpHandler>& GetOpHandlers() {
     return handlers;
 }
 
+// Build a one-line fingerprint of an op for diagnostics: opName plus operand
+// and result MLIR types (which include dtype + shape, e.g.
+// "tensor<3x4xcomplex<f32>>"). Used when a handler returns false without
+// throwing — most such failures are dtype/shape rejections, and the
+// fingerprint usually tells you what wasn't handled.
+std::string FormatOpFingerprint(mlir::Operation* op) {
+    std::string out;
+    llvm::raw_string_ostream os(out);
+    os << op->getName().getStringRef() << "(";
+    bool first = true;
+    for (auto operand : op->getOperands()) {
+        if (!first)
+            os << ", ";
+        first = false;
+        operand.getType().print(os);
+    }
+    os << ") -> (";
+    first = true;
+    for (auto resType : op->getResultTypes()) {
+        if (!first)
+            os << ", ";
+        first = false;
+        resType.print(os);
+    }
+    os << ")";
+    return out;
+}
+
 // Dispatch a single operation using the handler table
 bool DispatchOp(mlir::Operation* op, ValueMap& values, std::vector<mlx::core::array>& outputs,
                 ExecContext& ctx) {
@@ -347,19 +376,30 @@ bool DispatchOp(mlir::Operation* op, ValueMap& values, std::vector<mlx::core::ar
         return false;
     }
 
+    bool result;
     try {
         if (IsProfilingEnabled()) {
             auto start = Clock::now();
-            bool result = it->second(op, values, outputs, ctx);
+            result = it->second(op, values, outputs, ctx);
             auto end = Clock::now();
             GetProfilingState().RecordOp(opName, Duration(end - start).count());
-            return result;
+        } else {
+            result = it->second(op, values, outputs, ctx);
         }
-        return it->second(op, values, outputs, ctx);
     } catch (const std::exception& e) {
         MPS_LOG_ERROR("Exception dispatching %s: %s\n", opName.c_str(), e.what());
+        if (ctx.error_message.empty()) {
+            ctx.error_message = FormatOpFingerprint(op) + ": " + e.what();
+        }
         return false;
     }
+    if (!result && ctx.error_message.empty()) {
+        // Handler returned false without setting a reason (validation reject,
+        // unsupported dtype/shape combo, etc.). Synthesize a fingerprint from
+        // the op's operand and result types so the failure is greppable.
+        ctx.error_message = FormatOpFingerprint(op) + ": handler returned false";
+    }
+    return result;
 }
 
 }  // namespace
@@ -600,6 +640,7 @@ MlxExecuteResult MlxExecutable::Execute(const std::vector<MlxBuffer*>& inputs) {
     } else if (outputs.empty()) {
         if (!ExecuteFunction(parsed_module_.entry_func, inputArrays, outputs, ctx)) {
             MPS_LOG_ERROR("Failed to execute entry function\n");
+            result.error_message = std::move(ctx.error_message);
             return result;
         }
     }
@@ -611,6 +652,9 @@ MlxExecuteResult MlxExecutable::Execute(const std::vector<MlxBuffer*>& inputs) {
     if (outputs.size() != num_outputs_) {
         MPS_LOG_ERROR("Output count mismatch: expected %zu, got %zu\n", num_outputs_,
                       outputs.size());
+        if (result.error_message.empty()) {
+            result.error_message = std::move(ctx.error_message);
+        }
         return result;
     }
 
@@ -622,6 +666,7 @@ MlxExecuteResult MlxExecutable::Execute(const std::vector<MlxBuffer*>& inputs) {
             mlx::core::eval(outputs);
         } catch (const std::exception& e) {
             MPS_LOG_ERROR("MLX evaluation failed: %s\n", e.what());
+            result.error_message = std::string("eval: ") + e.what();
             return result;
         }
     }

--- a/src/pjrt_plugin/mlx_executable.cc
+++ b/src/pjrt_plugin/mlx_executable.cc
@@ -334,15 +334,20 @@ const std::unordered_map<std::string, OpHandler>& GetOpHandlers() {
     return handlers;
 }
 
-// Build a one-line fingerprint of an op for diagnostics: opName plus operand
-// and result MLIR types (which include dtype + shape, e.g.
-// "tensor<3x4xcomplex<f32>>"). Used when a handler returns false without
-// throwing — most such failures are dtype/shape rejections, and the
-// fingerprint usually tells you what wasn't handled.
+// Build a one-line fingerprint of an op for diagnostics: opName, identifying
+// attributes (e.g. `stablehlo.custom_call`'s `call_target_name`, which is the
+// only thing distinguishing ApproxTopK from Householder etc.), plus operand
+// and result MLIR types. Used when a handler returns false without throwing —
+// most such failures are dtype/shape rejections, and the fingerprint usually
+// tells you what wasn't handled.
 std::string FormatOpFingerprint(mlir::Operation* op) {
     std::string out;
     llvm::raw_string_ostream os(out);
-    os << op->getName().getStringRef() << "(";
+    os << op->getName().getStringRef();
+    if (auto targetAttr = op->getAttrOfType<mlir::StringAttr>("call_target_name")) {
+        os << "[" << targetAttr.getValue() << "]";
+    }
+    os << "(";
     bool first = true;
     for (auto operand : op->getOperands()) {
         if (!first)

--- a/src/pjrt_plugin/mlx_executable.h
+++ b/src/pjrt_plugin/mlx_executable.h
@@ -21,6 +21,10 @@ class MlxBuffer;
 
 struct MlxExecuteResult {
     std::vector<std::unique_ptr<MlxBuffer>> buffers;
+    // Underlying reason if execution failed (handler exception, MLX eval
+    // failure, etc.). Surfaced into the PJRT error message so Python sees
+    // the real cause instead of just "Output count mismatch".
+    std::string error_message;
 };
 
 // Output metadata for a single output

--- a/src/pjrt_plugin/ops/handler_utils.h
+++ b/src/pjrt_plugin/ops/handler_utils.h
@@ -30,6 +30,11 @@ using ValueMap = std::unordered_map<void*, mlx::core::array>;
 struct ExecContext {
     mlir::ModuleOp module;
     bool inside_compile = false;  // true when running inside mlx::core::compile()
+    // First underlying exception message seen during dispatch (e.g. MLX's
+    // "Only float32 is supported on Metal"). Empty if no failure or if the
+    // failure was a plain handler `return false` with no exception. The
+    // dispatcher writes only when empty so the first error wins.
+    std::string error_message;
 };
 
 // Op handler function type

--- a/src/pjrt_plugin/ops/handler_utils.h
+++ b/src/pjrt_plugin/ops/handler_utils.h
@@ -30,9 +30,10 @@ using ValueMap = std::unordered_map<void*, mlx::core::array>;
 struct ExecContext {
     mlir::ModuleOp module;
     bool inside_compile = false;  // true when running inside mlx::core::compile()
-    // First underlying exception message seen during dispatch (e.g. MLX's
-    // "Only float32 is supported on Metal"). Empty if no failure or if the
-    // failure was a plain handler `return false` with no exception. The
+    // First underlying failure reason seen during dispatch. Populated by the
+    // dispatcher with the MLX/handler exception text on a caught throw, or
+    // with a synthesized "<op fingerprint>: handler returned false" string on
+    // a silent return-false. Empty only if no failure occurred. The
     // dispatcher writes only when empty so the first error wins.
     std::string error_message;
 };

--- a/src/pjrt_plugin/pjrt_client.cc
+++ b/src/pjrt_plugin/pjrt_client.cc
@@ -273,9 +273,17 @@ PJRT_Error* MPS_Client_BufferFromHostBuffer(PJRT_Client_BufferFromHostBuffer_Arg
         return MakeError("Cannot create buffer: null data pointer provided");
     }
 
-    auto mps_buffer = client->client->BufferFromHostBuffer(
-        args->data, static_cast<int>(args->type), dims, byte_strides,
-        args->device ? args->device->device : nullptr);
+    std::unique_ptr<jax_mps::MlxBuffer> mps_buffer;
+    try {
+        mps_buffer = client->client->BufferFromHostBuffer(
+            args->data, static_cast<int>(args->type), dims, byte_strides,
+            args->device ? args->device->device : nullptr);
+    } catch (const std::exception& e) {
+        // PjrtDtypeToMlx throws on unsupported dtypes (notably F64); surface the
+        // message as a clean PJRT error so JAX sees the real cause instead of
+        // an uncaught exception across the C boundary.
+        return MakeError(std::string("BufferFromHostBuffer failed: ") + e.what());
+    }
 
     if (!mps_buffer) {
         return MakeError("Failed to create Metal buffer. GPU memory may be exhausted.");

--- a/src/pjrt_plugin/pjrt_executable.cc
+++ b/src/pjrt_plugin/pjrt_executable.cc
@@ -212,9 +212,12 @@ PJRT_Error* MPS_LoadedExecutable_Execute(PJRT_LoadedExecutable_Execute_Args* arg
     // Execute
     auto result = mlx_executable->Execute(inputs);
 
-    // Check for execution errors - validate output count matches expected
+    // Check for execution errors. A non-empty error_message always indicates a
+    // failure inside Execute() (handler exception, silent return-false, or MLX
+    // eval failure) — surface it even when the output count happens to match
+    // (e.g. a zero-output executable whose handler still failed).
     size_t expected_outputs = mlx_executable->num_outputs();
-    if (result.buffers.size() != expected_outputs) {
+    if (result.buffers.size() != expected_outputs || !result.error_message.empty()) {
         std::string msg = "Output count mismatch: expected " + std::to_string(expected_outputs) +
                           ", got " + std::to_string(result.buffers.size());
         if (!result.error_message.empty()) {

--- a/src/pjrt_plugin/pjrt_executable.cc
+++ b/src/pjrt_plugin/pjrt_executable.cc
@@ -215,8 +215,12 @@ PJRT_Error* MPS_LoadedExecutable_Execute(PJRT_LoadedExecutable_Execute_Args* arg
     // Check for execution errors - validate output count matches expected
     size_t expected_outputs = mlx_executable->num_outputs();
     if (result.buffers.size() != expected_outputs) {
-        return MakeError("Output count mismatch: expected " + std::to_string(expected_outputs) +
-                         ", got " + std::to_string(result.buffers.size()));
+        std::string msg = "Output count mismatch: expected " + std::to_string(expected_outputs) +
+                          ", got " + std::to_string(result.buffers.size());
+        if (!result.error_message.empty()) {
+            msg += " (" + result.error_message + ")";
+        }
+        return MakeError(msg);
     }
 
     // Allocate output buffer array


### PR DESCRIPTION
## Summary

The upstream JAX suite reported **964 generic `Output count mismatch: expected N, got 0`** failures whose only signal was the count itself — the real cause was only visible on stderr, not in the Python exception or the JUnit XML. This PR threads the underlying reason through to the PJRT error so failures are greppable, fixes the f64 buffer-creation throw that was propagating uncaught across the C boundary, and adds a narrow runner-level skip for genuinely-unsupported f64 tests.

## Changes

- **`ExecContext.error_message`** + `MlxExecuteResult.error_message`: the dispatcher writes the underlying exception (e.g. `[scatter] GPU scatter does not yet support complex64`) into `ctx.error_message`; the eval-failure path does the same. `pjrt_executable` appends it to the `Output count mismatch` message so JAX sees the real cause.
- **`FormatOpFingerprint`**: when a handler returns `false` silently (no exception — e.g. a dtype/shape rejection that just bails), the dispatcher synthesizes `<opname>(operand types) -> (result types): handler returned false`. Bucketing now possible from the JUnit XML alone.
- **`MPS_Client_BufferFromHostBuffer` try/catch**: `PjrtDtypeToMlx` already throws on F64 with a clean message, but the call site didn't catch it — uncaught exceptions across the PJRT C boundary become opaque errors. Wrap in try/catch and surface the message via `MakeError`.
- **`scripts/_pytest_skip_unsupported_plugin.py`**: new pytest plugin that converts failures matching the literal `MLX does not support float64` message into skipped. Loaded only by `run_jax_tests.py`. Filter is intentionally narrow — never matches `Only float32 is supported on Metal` (which also fires for complex64/f16/bf16 and would mask real bugs).

## Why only f64 skips

f64 is the only dtype Apple GPUs fundamentally can't run. Everything else — complex64 in linalg, Metal SVD's 51×51 cap, ApproxTopK custom_calls, missing complex64 kernels (arange/Expm1), distributed collectives — is either an MLX kernel we haven't written or an MLX TODO. Those should stay as failures so the work remains visible.

## Example before/after

Before:
```
jax.errors.JaxRuntimeError: INTERNAL: Output count mismatch: expected 2, got 0
```

After (caught exception path):
```
jax.errors.JaxRuntimeError: INTERNAL: Output count mismatch: expected 2, got 0
  (eval: [Eigh::eval_gpu] Only float32 is supported on Metal.)
```

After (silent-false path):
```
jax.errors.JaxRuntimeError: INTERNAL: Output count mismatch: expected 2, got 0
  (stablehlo.custom_call(tensor<200x500xf32>, tensor<200x500xi32>, tensor<f32>, tensor<i32>) -> (tensor<200x1xf32>, tensor<200x1xi32>): handler returned false)
```

After (genuine f64):
```
SKIPPED [1] MLX does not support float64 on Metal
```

## Test plan

- [x] `uv run pytest` — internal suite passes (1 xdist-flake on `numpyro.Chi2_1-jit`, passes when rerun alone).
- [x] Synthetic test confirms f64 → SKIPPED, f32 → PASSED.
- [x] `testEigh1` (complex64) — still fails with the propagated MLX message (no longer masked).
- [x] `testSVD1` (size-cap) — still fails with `(eval: [SVD::eval_gpu] Metal SVD currently supports matrices up to 51×51. Got 53×29.)`.
- [x] `ann_test::test_approx_max_k0` (previously silent) — now shows fingerprint pointing at the unhandled `ApproxTopK` custom_call target.
- [x] Full JAX 0.10.0 upstream suite ran with the plugin: 24960/26928 = 92.7% (badge update was already on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)