### PR TITLE
fix(svd): default algorithm kwarg to None

### DIFF
--- a/src/jax_plugins/mps/ops.py
+++ b/src/jax_plugins/mps/ops.py
@@ -620,7 +620,7 @@ def _svd_via_transpose(operand, *, full_matrices, compute_uv):
 
 
 def _svd_lowering(
-    ctx, operand, *, full_matrices, compute_uv, subset_by_index, algorithm
+    ctx, operand, *, full_matrices, compute_uv, subset_by_index, algorithm=None
 ):
     """MPS lowering for svd: emit a custom_call @mps.svd."""
     if subset_by_index is not None:

--- a/tests/configs/linalg.py
+++ b/tests/configs/linalg.py
@@ -27,6 +27,22 @@ def _svd_values(A):
     return jnp.linalg.svd(A, compute_uv=False)
 
 
+def _svd_via_primitive_no_algorithm(A):
+    """Call lax.linalg.svd_p directly without the ``algorithm`` kwarg.
+
+    Matches the call shape used by `jax/_src/internal_test_util/test_harnesses.py`
+    for the SVD harness (which omits `algorithm`). Exercises the MPS lowering
+    path where `algorithm` is absent from the primitive's params dict — a
+    signature regression we shipped briefly when JAX added the kwarg.
+    """
+    from jax import lax
+
+    (s,) = lax.linalg.svd_p.bind(
+        A, full_matrices=False, compute_uv=False, subset_by_index=None
+    )
+    return s
+
+
 def _svd_reconstruct(A):
     """Reconstruct A from its SVD to verify correctness without sign issues."""
     U, S, Vh = jnp.linalg.svd(A, full_matrices=False)
@@ -340,6 +356,17 @@ def make_linalg_op_configs():
             lambda key: random.normal(key, (2, 4)),
             name="svd_reconstruct_full_2x4",
             grad_xfail="Singular value decomposition JVP not implemented for full matrices",
+        )
+
+        # Direct svd_p.bind without `algorithm` kwarg — matches the upstream
+        # test_harnesses.py shape, which is the path that triggered the
+        # `_svd_lowering() missing 1 required keyword-only argument:
+        # 'algorithm'` regression. The public jnp.linalg.svd always passes
+        # `algorithm`, so this only fires through the primitive directly.
+        yield OperationTestConfig(
+            _svd_via_primitive_no_algorithm,
+            lambda key: random.normal(key, (3, 3)),
+            name="svd_via_primitive_no_algorithm",
         )
 
         # Batched SVD


### PR DESCRIPTION
## Summary

The upstream JAX harness at `jax/_src/internal_test_util/test_harnesses.py:1858` calls `lax.linalg.svd_p.bind(...)` **without** the `algorithm` kwarg, and the shape-poly tests inherit that signature. Our registered MPS lowering required `algorithm`, so this path failed with:

\`\`\`
TypeError: _svd_lowering() missing 1 required keyword-only argument: 'algorithm'
\`\`\`

JAX's own \`_svd_cpu_gpu_lowering\` defaults \`algorithm=None\`. Match that. The existing \`if algorithm is not None: raise NotImplementedError\` still rejects explicit algorithm selection — only the missing-kwarg path changes.

## Test plan

- [x] New OperationTestConfig \`svd_via_primitive_no_algorithm\` calls \`svd_p.bind\` directly without the kwarg (TDD: confirmed red before the fix, green after).
- [x] All other SVD configs still pass (80 passed, 8 xfailed pre-existing).
- [x] Pre-commit hooks pass.

Cluster impact: ~20 \`shape_poly_test\` failures progressed past this TypeError. (They now surface an unrelated serialization-compat issue, which is a separate cluster.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)