### PR TITLE
fix(sort): cast bool inputs to int8 around the sort

### DIFF
--- a/src/pjrt_plugin/ops/sort_fft_complex.cc
+++ b/src/pjrt_plugin/ops/sort_fft_complex.cc
@@ -164,18 +164,29 @@ bool HandleSort(mlir::Operation* op, ValueMap& values, std::vector<mlx::core::ar
         auto* input = RequireValue(values, sortOp.getInputs()[0], "stablehlo.sort");
         if (!input)
             return false;
-        auto result = mlx::core::sort(*input, dimension);
+        // MLX's Metal block_sort kernel has no bool variant
+        // (`ncarg_block_sort_bool__uint32_*` is not loaded). Cast to int8
+        // around the sort and cast the result back to bool.
+        const bool inputIsBool = input->dtype() == mlx::core::bool_;
+        const auto sortInput = inputIsBool ? mlx::core::astype(*input, mlx::core::int8) : *input;
+        auto result = mlx::core::sort(sortInput, dimension);
         if (!ascending) {
             result = ReverseAxis(result, dimension);
         }
+        if (inputIsBool) {
+            result = mlx::core::astype(result, mlx::core::bool_);
+        }
         values.emplace(ToKey(op->getResult(0)), std::move(result));
     } else {
-        // Sort-by-key
+        // Sort-by-key. Only the keys need int8 casting — take_along_axis on
+        // bool values is supported by MLX's gather kernel.
         auto* keys = RequireValue(values, sortOp.getInputs()[0], "stablehlo.sort");
         if (!keys)
             return false;
 
-        auto indices = mlx::core::argsort(*keys, dimension);
+        const auto argsortInput =
+            keys->dtype() == mlx::core::bool_ ? mlx::core::astype(*keys, mlx::core::int8) : *keys;
+        auto indices = mlx::core::argsort(argsortInput, dimension);
         if (!ascending) {
             indices = ReverseAxis(indices, dimension);
         }

--- a/src/pjrt_plugin/ops/sort_fft_complex.cc
+++ b/src/pjrt_plugin/ops/sort_fft_complex.cc
@@ -184,11 +184,23 @@ bool HandleSort(mlir::Operation* op, ValueMap& values, std::vector<mlx::core::ar
         if (!keys)
             return false;
 
-        const auto argsortInput =
-            keys->dtype() == mlx::core::bool_ ? mlx::core::astype(*keys, mlx::core::int8) : *keys;
-        auto indices = mlx::core::argsort(argsortInput, dimension);
-        if (!ascending) {
-            indices = ReverseAxis(indices, dimension);
+        const bool keysAreBool = keys->dtype() == mlx::core::bool_;
+        const auto argsortInput = keysAreBool ? mlx::core::astype(*keys, mlx::core::int8) : *keys;
+        mlx::core::array indices = mlx::core::array(0);
+        if (!ascending && keysAreBool) {
+            // Bool inputs are tie-heavy. A `cast → argsort → reverse` would
+            // flip the tie order within the equal-True and equal-False
+            // groups and violate JAX's stable-descending semantics. Sort the
+            // flipped key (1 - x) ascending instead — argsort is stable, so
+            // ties resolve to ascending original index in either direction.
+            auto descKey =
+                mlx::core::subtract(mlx::core::array(static_cast<int8_t>(1)), argsortInput);
+            indices = mlx::core::argsort(descKey, dimension);
+        } else {
+            indices = mlx::core::argsort(argsortInput, dimension);
+            if (!ascending) {
+                indices = ReverseAxis(indices, dimension);
+            }
         }
 
         for (size_t i = 0; i < numInputs; ++i) {

--- a/tests/configs/sort.py
+++ b/tests/configs/sort.py
@@ -456,5 +456,38 @@ def make_sort_op_configs():
                 name="lax.sort_key_val.bool_keys",
             )
         )
+        # Descending bool sort — exercises the `descending=True` branch.
+        configs.append(
+            OperationTestConfig(
+                lambda x: jnp.sort(x, descending=True),
+                jnp.array([True, False, True, True, False, False, True]),
+                differentiable_argnums=(),
+                name="jnp.sort.bool.descending",
+            )
+        )
+        # Stable descending argsort with tie-heavy bool keys: a naive
+        # cast→argsort ascending→reverse would invert tie order within the
+        # equal-True and equal-False groups; the handler sorts on a flipped
+        # key to preserve stable descending semantics.
+        configs.append(
+            OperationTestConfig(
+                lambda x: jnp.argsort(x, descending=True, stable=True),
+                jnp.array([True, False, True, False, True]),
+                differentiable_argnums=(),
+                name="jnp.argsort.bool.descending_stable",
+            )
+        )
+        # sort_key_val with bool values + numeric keys — exercises the
+        # take_along_axis-on-bool branch where bool values pass through
+        # without casting.
+        configs.append(
+            OperationTestConfig(
+                lambda keys, vals: lax.sort_key_val(keys, vals, dimension=0),
+                jnp.arange(5, dtype=jnp.float32),
+                jnp.array([True, False, True, False, True]),
+                differentiable_argnums=(0,),
+                name="lax.sort_key_val.bool_values",
+            )
+        )
 
         return configs

--- a/tests/configs/sort.py
+++ b/tests/configs/sort.py
@@ -423,4 +423,38 @@ def make_sort_op_configs():
             )
         )
 
+        # =============================================================
+        # bool sort — MLX's Metal block_sort kernel has no bool variant
+        # (Unable to load kernel ncarg_block_sort_bool__uint32_*). The
+        # handler casts bool → int8 around the sort. Exercised by
+        # jnp.compress / jnp.extract via lax.sort, plus argsort/lexsort.
+        # =============================================================
+        configs.append(
+            OperationTestConfig(
+                lambda x: jnp.sort(x),
+                jnp.array([True, False, True, True, False, False, True]),
+                differentiable_argnums=(),
+                name="jnp.sort.bool.1d",
+            )
+        )
+        configs.append(
+            OperationTestConfig(
+                lambda x: jnp.argsort(x),
+                jnp.array([[True, False, True], [False, True, False]]),
+                differentiable_argnums=(),
+                name="jnp.argsort.bool.2d",
+            )
+        )
+        # sort-by-key with bool keys exercises the multi-input path
+        # (argsort over a bool tensor + take_along_axis on values).
+        configs.append(
+            OperationTestConfig(
+                lambda keys, vals: lax.sort_key_val(keys, vals, dimension=0),
+                jnp.array([True, False, True, False, True]),
+                jnp.arange(5, dtype=jnp.float32),
+                differentiable_argnums=(1,),
+                name="lax.sort_key_val.bool_keys",
+            )
+        )
+
         return configs


### PR DESCRIPTION
## Summary

MLX's Metal block_sort kernel has no bool variant — calls fail with:

\`\`\`
Unable to load kernel ncarg_block_sort_bool__uint32_bn32_tn4
\`\`\`

Cast bool → int8 around \`mlx::core::sort\` / \`mlx::core::argsort\` and cast the single-input result back to bool. The sort-by-key path only casts keys (not values), since \`take_along_axis\` on bool values is supported.

## Test plan

- [x] Three new \`OperationTestConfig\` entries (\`jnp.sort.bool.1d\`, \`jnp.argsort.bool.2d\`, \`lax.sort_key_val.bool_keys\`) — TDD: confirmed red before fix, green after.
- [x] Full sort suite (140 passed, 44 skipped) still clean.
- [x] Pre-commit hooks pass.

Cluster impact: ~15 upstream JAX failures in \`lax_numpy_test::testCompressSize*\`, \`testExtractSize*\`, argsort/lexsort over bool tensors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)