### PR TITLE
fix(reduce_window): support Prod in the pooling tier

### DIFF
--- a/src/pjrt_plugin/ops/reduction.cc
+++ b/src/pjrt_plugin/ops/reduction.cc
@@ -312,8 +312,8 @@ bool HandleReduceWindow(mlir::Operation* op, ValueMap& values,
     }
 
     if (reduceType != ReduceType::Max && reduceType != ReduceType::Sum &&
-        reduceType != ReduceType::Min) {
-        MPS_LOG_ERROR("stablehlo.reduce_window: pooling supports max/sum/min only\n");
+        reduceType != ReduceType::Min && reduceType != ReduceType::Prod) {
+        MPS_LOG_ERROR("stablehlo.reduce_window: pooling supports max/sum/min/prod only\n");
         return false;
     }
 
@@ -377,6 +377,8 @@ bool HandleReduceWindow(mlir::Operation* op, ValueMap& values,
             return mlx::core::max(windowed, reduceAxes);
         if (reduceType == ReduceType::Min)
             return mlx::core::min(windowed, reduceAxes);
+        if (reduceType == ReduceType::Prod)
+            return mlx::core::prod(windowed, reduceAxes);
         return mlx::core::sum(windowed, reduceAxes);
     }();
 

--- a/src/pjrt_plugin/ops/reduction.cc
+++ b/src/pjrt_plugin/ops/reduction.cc
@@ -317,6 +317,44 @@ bool HandleReduceWindow(mlir::Operation* op, ValueMap& values,
         return false;
     }
 
+    // For Prod, the StableHLO reduction semantics include the init value as a
+    // factor in every window (and as the value of any padded slots when the
+    // window crosses the padding region). The handler emits a plain
+    // `prod(windowed)` and uses the init only as the pad value, so the result
+    // is correct exactly when init is the multiplicative identity (1). Reject
+    // non-identity init rather than silently dropping the factor.
+    if (reduceType == ReduceType::Prod) {
+        bool initIsOne = false;
+        // Compile-time fast path: the init is a stablehlo.constant.
+        if (auto initConst = rwOp.getInitValues()[0].getDefiningOp<mlir::stablehlo::ConstantOp>()) {
+            if (auto attr = mlir::dyn_cast<mlir::DenseElementsAttr>(initConst.getValue())) {
+                if (attr.isSplat()) {
+                    if (mlir::isa<mlir::FloatType>(attr.getElementType())) {
+                        initIsOne = attr.getSplatValue<llvm::APFloat>().convertToDouble() == 1.0;
+                    } else if (mlir::isa<mlir::IntegerType>(attr.getElementType())) {
+                        initIsOne = attr.getSplatValue<llvm::APInt>().getSExtValue() == 1;
+                    }
+                }
+            }
+        } else if (auto* initArr =
+                       RequireValue(values, rwOp.getInitValues()[0], "stablehlo.reduce_window")) {
+            // Eager mode threads the init as a function argument; check the
+            // runtime mlx::core::array against scalar 1. eval() is necessary
+            // because the value may still be lazy, but the init array is
+            // 0-dim so the sync is trivial.
+            auto cmp =
+                mlx::core::all(mlx::core::equal(*initArr, mlx::core::ones({}, initArr->dtype())));
+            cmp.eval();
+            initIsOne = cmp.item<bool>();
+        }
+        if (!initIsOne) {
+            MPS_LOG_ERROR(
+                "stablehlo.reduce_window: prod requires init=1 (multiplicative "
+                "identity); non-identity init is not supported\n");
+            return false;
+        }
+    }
+
     // Pad input if needed.
     mlx::core::array padded = *input;
     bool needsPad = false;

--- a/tests/configs/reduction.py
+++ b/tests/configs/reduction.py
@@ -125,6 +125,19 @@ def make_reduction_op_configs():
                 name="prodpool2d-valid",
                 differentiable_argnums=(),
             ),
+            # Prod pool with SAME padding — exercises the padded prod branch.
+            # MLX's pad fills boundary slots with the init value (1, the
+            # multiplicative identity) so out-of-bounds slots don't change
+            # the product. Required to confirm the validation logic accepts
+            # this path.
+            OperationTestConfig(
+                lambda x: lax.reduce_window(
+                    x, 1.0, lax.mul, (1, 3, 3, 1), (1, 1, 1, 1), "same"
+                ),
+                lambda key: random.uniform(key, (2, 8, 8, 3), minval=0.5, maxval=1.5),
+                name="prodpool2d-same",
+                differentiable_argnums=(),
+            ),
             # Max pool 2D SAME padding: window=(1,3,3,1), stride=(1,1,1,1)
             OperationTestConfig(
                 lambda x: lax.reduce_window(

--- a/tests/configs/reduction.py
+++ b/tests/configs/reduction.py
@@ -56,6 +56,14 @@ def make_reduction_op_configs():
                 lambda key: random.uniform(key, (3, 5), minval=0.5, maxval=1.5),
                 name="cumprod-axis1",
             ),
+            # 1-element axis: cumulative detection skips axes where
+            # windowDims[i]==1, so this falls through to the pooling tier
+            # — which must accept Prod for the lowering to succeed.
+            OperationTestConfig(
+                lambda x: jnp.cumprod(x, axis=0),
+                lambda key: random.uniform(key, (1,), minval=0.5, maxval=1.5),
+                name="cumprod-axis0-size1",
+            ),
             OperationTestConfig(
                 lambda x: lax.cummax(x, axis=1),
                 lambda key: random.normal(key, (3, 5)),
@@ -102,6 +110,20 @@ def make_reduction_op_configs():
                 ),
                 lambda key: random.normal(key, (2, 8, 8, 3)),
                 name="sumpool2d-valid",
+            ),
+            # Prod pool 2D: same pattern as sum, but with mul reduction. The
+            # JAX upstream tests (testCumSumProd, testSphHarmY) lower
+            # cumulative-prod to reduce_window when the cumulative pattern
+            # isn't detected, so the pooling tier must support Prod too.
+            # JAX itself doesn't define a reverse-mode VJP for prod
+            # reduce_window, so this config exercises the forward path only.
+            OperationTestConfig(
+                lambda x: lax.reduce_window(
+                    x, 1.0, lax.mul, (1, 2, 2, 1), (1, 2, 2, 1), "valid"
+                ),
+                lambda key: random.uniform(key, (2, 8, 8, 3), minval=0.5, maxval=1.5),
+                name="prodpool2d-valid",
+                differentiable_argnums=(),
             ),
             # Max pool 2D SAME padding: window=(1,3,3,1), stride=(1,1,1,1)
             OperationTestConfig(


### PR DESCRIPTION
## Summary

JAX lowers \`lax.reduce_window(x, 1.0, lax.mul, ...)\` and certain \`cumprod\` shapes (e.g. 1-element axes where cumulative detection skips the axis via the \`windowDims[i]==1\` continue branch) into \`stablehlo.reduce_window\` with a \`mul\` body. The pooling tier in \`HandleReduceWindow\` was rejecting anything but max/sum/min, so these failed silently with \"handler returned false\".

Add Prod to the pooling-tier accepted reduce types and emit \`mlx::core::prod(windowed, reduceAxes)\` for it.

## Test plan

- [x] New OperationTestConfigs \`cumprod-axis0-size1\` (pooling fallback) and \`prodpool2d-valid\` (explicit prod pool) — TDD: confirmed red before fix, green after.
- [x] Full reduction suite (150 passed, 6 skipped) still clean.
- [x] Pre-commit hooks pass.

Cluster impact: ~13 upstream JAX failures in \`testCumSumProd*\`, \`testSphHarmY*\`, \`testCumulativeProd*\`.

Variadic reduce_window (the (val, idx) argmax-pair body in \`testReduceWindowVariadic\`) is a separate cluster — left for a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)