### PR TITLE
feat(arithmetic): add stablehlo.logistic handler (mlx::core::sigmoid)

### DIFF
--- a/src/jax_plugins/mps/ops.py
+++ b/src/jax_plugins/mps/ops.py
@@ -19,6 +19,7 @@ from jax._src.lax import lax as lax_lax
 from jax._src.lax import linalg as lax_linalg
 from jax._src.lax import special as lax_special
 from jax._src.lib.mlir import ir  # pyright: ignore[reportPrivateImportUsage]
+from jax._src.lib.mlir.dialects import hlo
 
 
 def _aval_to_ir_type(aval: core.ShapedArray) -> ir.Type:
@@ -693,6 +694,21 @@ def _make_native_unary_lowering(call_target_name):
     return _lowering
 
 
+def _logistic_lowering(ctx, x, *, accuracy=None):
+    """MPS lowering for logistic_p: emit a native stablehlo.logistic op.
+
+    Upstream JAX lowers logistic_p to the explicit 1/(1+exp(-x)) decomposition
+    because the HLO LogisticOp lowering had numerical issues on some backends
+    (see the commented-out registration in jax/_src/lax/lax.py). On MPS we route
+    stablehlo.logistic to mlx::core::sigmoid, which is numerically stable, so we
+    keep it as a single op instead of a four-op decomposition. The accuracy
+    attribute is irrelevant to the MLX kernel and is dropped (matching
+    logistic_impl).
+    """
+    del accuracy
+    return [hlo.logistic(x)]
+
+
 def register_fused_ops():
     """Register MPS MLIR lowerings for fused custom_calls and related ops.
 
@@ -747,6 +763,10 @@ def register_fused_ops():
         mlir.register_lowering(
             prim, _make_native_unary_lowering(target), platform="mps"
         )
+
+    # logistic_p decomposes to 1/(1+exp(-x)) upstream; on MPS keep it as a
+    # single stablehlo.logistic that dispatches to mlx::core::sigmoid.
+    mlir.register_lowering(lax_lax.logistic_p, _logistic_lowering, platform="mps")
 
     # Fallback lowerings for non-MPS platforms (CPU, GPU).
     mlir.register_lowering(

--- a/src/pjrt_plugin/ops/arithmetic.cc
+++ b/src/pjrt_plugin/ops/arithmetic.cc
@@ -514,7 +514,8 @@ void RegisterArithmeticHandlers(std::unordered_map<std::string, OpHandler>& hand
     handlers.insert({"stablehlo.cosine", MakeUnaryHandler("stablehlo.cosine", mlx::core::cos)});
     handlers.insert({"stablehlo.tanh", MakeUnaryHandler("stablehlo.tanh", mlx::core::tanh)});
     handlers.insert({"stablehlo.tan", MakeUnaryHandler("stablehlo.tan", mlx::core::tan)});
-    handlers.insert({"stablehlo.logistic", MakeUnaryHandler("stablehlo.logistic", mlx::core::sigmoid)});
+    handlers.insert(
+        {"stablehlo.logistic", MakeUnaryHandler("stablehlo.logistic", mlx::core::sigmoid)});
     handlers.insert({"stablehlo.sign", HandleSign});
     handlers.insert(
         {"stablehlo.log_plus_one", MakeUnaryHandler("stablehlo.log_plus_one", mlx::core::log1p)});

--- a/src/pjrt_plugin/ops/arithmetic.cc
+++ b/src/pjrt_plugin/ops/arithmetic.cc
@@ -514,6 +514,7 @@ void RegisterArithmeticHandlers(std::unordered_map<std::string, OpHandler>& hand
     handlers.insert({"stablehlo.cosine", MakeUnaryHandler("stablehlo.cosine", mlx::core::cos)});
     handlers.insert({"stablehlo.tanh", MakeUnaryHandler("stablehlo.tanh", mlx::core::tanh)});
     handlers.insert({"stablehlo.tan", MakeUnaryHandler("stablehlo.tan", mlx::core::tan)});
+    handlers.insert({"stablehlo.logistic", MakeUnaryHandler("stablehlo.logistic", mlx::core::sigmoid)});
     handlers.insert({"stablehlo.sign", HandleSign});
     handlers.insert(
         {"stablehlo.log_plus_one", MakeUnaryHandler("stablehlo.log_plus_one", mlx::core::log1p)});

--- a/tests/configs/unary.py
+++ b/tests/configs/unary.py
@@ -1,5 +1,5 @@
 import numpy
-from jax import lax, random
+from jax import lax, nn, random
 from jax import numpy as jnp
 from jax.scipy import special
 
@@ -147,6 +147,10 @@ def make_unary_op_configs():
         ),
         OperationTestConfig(
             jnp.cbrt,
+            lambda key: random.normal(key, (16,)),
+        ),
+        OperationTestConfig(
+            nn.sigmoid,
             lambda key: random.normal(key, (16,)),
         ),
         OperationTestConfig(


### PR DESCRIPTION
Adds a `stablehlo.logistic` op handler mapping to `mlx::core::sigmoid`.

`jax.nn.sigmoid` and `jax.nn.silu` both lower to `stablehlo.logistic`; without this handler they fall back to CPU on every call.

Adds an `OperationTestConfig` for `nn.sigmoid` in `tests/configs/unary.py`.

## Test plan
- [ ] `uv run pytest tests/` passes
- [ ] Training loop using `jax.nn.silu` / `jax.nn.sigmoid` runs fully on MPS without CPU round-trips
