### PR TITLE
Fix stablehlo.scatter for multi-axis, multi-window, and mixed patterns

### DIFF
--- a/src/pjrt_plugin/ops/gather_scatter.cc
+++ b/src/pjrt_plugin/ops/gather_scatter.cc
@@ -354,7 +354,9 @@ bool HandleScatter(mlir::Operation* op, ValueMap& values, std::vector<mlx::core:
     bool hasIdxVecDim = indexVectorDim < scatterIndices->ndim();
 
     // ===== Window scatter path: scatter axes with window extent > 1 =====
-    if (hasWindowScatter) {
+    // Mixed point-and-window scatter (non-empty insertedWindowDims plus
+    // window-extent > 1 on other scatter axes).
+    if (hasWindowScatter && insertedWindowDims.empty()) {
         // For multi-axis window scatter, use slice_update loop.
         if (scatterDimsToOperandDims.size() > 1) {
             if (!inputBatchingDims.empty()) {
@@ -470,6 +472,23 @@ bool HandleScatter(mlir::Operation* op, ValueMap& values, std::vector<mlx::core:
                         auto current = mlx::core::slice(result, startArr, axes, sliceSizes);
                         result = mlx::core::slice_update(result, mlx::core::add(current, updateVal),
                                                          startArr, axes);
+                        break;
+                    }
+                    case ScatterType::Mul: {
+                        if (!insertedWindowDims.empty() ||
+                            static_cast<int>(updateVal.ndim()) != operand->ndim()) {
+                            MPS_LOG_ERROR(
+                                "stablehlo.scatter: multi-dim window scatter Mul requires "
+                                "empty insertedWindowDims and operand-rank updates\n");
+                            return false;
+                        }
+                        mlx::core::Shape sliceSizes(operand->shape());
+                        for (int axis : axes) {
+                            sliceSizes[axis] = updateVal.shape(axis);
+                        }
+                        auto current = mlx::core::slice(result, startArr, axes, sliceSizes);
+                        result = mlx::core::slice_update(
+                            result, mlx::core::multiply(current, updateVal), startArr, axes);
                         break;
                     }
                     default:
@@ -650,21 +669,17 @@ bool HandleScatter(mlir::Operation* op, ValueMap& values, std::vector<mlx::core:
     }
     auto tShape = transposedUpdates.shape();
 
-    std::set<int> coveredDims;
-    for (auto d : insertedWindowDims)
-        coveredDims.insert(static_cast<int>(d));
-    for (auto d : inputBatchingDims)
-        coveredDims.insert(static_cast<int>(d));
-    for (auto d : scatterDimsToOperandDims)
-        coveredDims.insert(static_cast<int>(d));
-
     mlx::core::Shape newShape;
     for (int i = 0; i < numIdxDims; ++i) {
         newShape.push_back(tShape[i]);
     }
     int windowIdx = 0;
     for (int d = 0; d < operand->ndim(); ++d) {
-        if (coveredDims.count(d)) {
+        // Inserted / input-batching operand dims are collapsed in updates
+        // (no slot in tShape) — emit a size-1 entry. Every other operand dim
+        // (window dim, whether or not it is also a scatter axis) has a real
+        // entry in the transposed-updates shape that must be consumed.
+        if (insertedSet.count(d) || batchingSet.count(d)) {
             newShape.push_back(1);
         } else {
             newShape.push_back(tShape[numIdxDims + windowIdx++]);

--- a/src/pjrt_plugin/ops/gather_scatter.cc
+++ b/src/pjrt_plugin/ops/gather_scatter.cc
@@ -458,11 +458,10 @@ bool HandleScatter(mlir::Operation* op, ValueMap& values, std::vector<mlx::core:
                         result = mlx::core::slice_update(result, updateVal, startArr, axes);
                         break;
                     case ScatterType::Add: {
-                        if (!insertedWindowDims.empty() ||
-                            static_cast<int>(updateVal.ndim()) != operand->ndim()) {
+                        if (static_cast<int>(updateVal.ndim()) != operand->ndim()) {
                             MPS_LOG_ERROR(
                                 "stablehlo.scatter: multi-dim window scatter Add requires "
-                                "empty insertedWindowDims and operand-rank updates\n");
+                                "operand-rank updates\n");
                             return false;
                         }
                         mlx::core::Shape sliceSizes(operand->shape());
@@ -475,11 +474,10 @@ bool HandleScatter(mlir::Operation* op, ValueMap& values, std::vector<mlx::core:
                         break;
                     }
                     case ScatterType::Mul: {
-                        if (!insertedWindowDims.empty() ||
-                            static_cast<int>(updateVal.ndim()) != operand->ndim()) {
+                        if (static_cast<int>(updateVal.ndim()) != operand->ndim()) {
                             MPS_LOG_ERROR(
                                 "stablehlo.scatter: multi-dim window scatter Mul requires "
-                                "empty insertedWindowDims and operand-rank updates\n");
+                                "operand-rank updates\n");
                             return false;
                         }
                         mlx::core::Shape sliceSizes(operand->shape());

--- a/tests/configs/slice.py
+++ b/tests/configs/slice.py
@@ -81,6 +81,22 @@ def make_slice_op_configs():
                 lambda key: jnp.array(1.0, dtype=jnp.float32),
                 name="full_index_scatter_rank4",
             ),
+            # Multi-axis slice scatter on rank-4
+            OperationTestConfig(
+                lambda x, mask: x.at[:, :, 0:1, :].mul(mask),
+                lambda key: jnp.ones((2, 3, 4, 4), dtype=jnp.float32),
+                lambda key: jnp.full((2, 3, 1, 4), 0.5, dtype=jnp.float32),
+                name="multi_axis_slice_scatter_mul_rank4",
+            ),
+            # Mixed point-and-window scatter: integer index on dim 0 (collapsed
+            # via inserted_window_dims) plus static slices on the trailing dims
+            # (window-extent > 1).
+            OperationTestConfig(
+                lambda x, u: x.at[jnp.array([1, 3]), 1:5, 1:5, 1:5].add(u),
+                lambda key: jnp.zeros((5, 8, 8, 8), dtype=jnp.float32),
+                lambda key: jnp.full((2, 4, 4, 4), 1.0, dtype=jnp.float32),
+                name="mixed_point_window_scatter_add_rank4",
+            ),
             # Non-zero indices
             OperationTestConfig(
                 lambda x, val: x.at[1, 1, 1].set(val),

--- a/tests/configs/slice.py
+++ b/tests/configs/slice.py
@@ -97,6 +97,14 @@ def make_slice_op_configs():
                 lambda key: jnp.full((2, 4, 4, 4), 1.0, dtype=jnp.float32),
                 name="mixed_point_window_scatter_add_rank4",
             ),
+            # Multi-axis window scatter Mul: window extent > 1 on more
+            # than one axis, no inserted dims.
+            OperationTestConfig(
+                lambda x, u: x.at[1:3, 0:2].mul(u),
+                lambda key: jnp.ones((5, 5), dtype=jnp.float32),
+                lambda key: jnp.full((2, 2), 0.5, dtype=jnp.float32),
+                name="multi_axis_window_scatter_mul_rank2",
+            ),
             # Non-zero indices
             OperationTestConfig(
                 lambda x, val: x.at[1, 1, 1].set(val),


### PR DESCRIPTION
# Fix `stablehlo.scatter` for multi-axis slice, multi-axis window, and mixed point/window patterns

## Summary

Several common `jax.numpy` indexed-update expressions lower to `stablehlo.scatter`
forms that the current handler rejects or miscomputes. This PR fixes three
closely-related cases in `HandleScatter`, all reachable from ordinary
`arr.at[...].set/add/mul(...)` on rank ≥ 3 arrays:

1. **General-point scatter with a covered scatter axis whose `tShape` window
   slot is size 1.** The `newShape` reshape loop emitted `1` for every operand
   dim in `coveredDims` but did not consume the corresponding (size-1) slot in
   `tShape`, so every subsequent uncovered dim read from the wrong position.
   Result: `Cannot reshape array of size N into shape (...)`.
2. **Multi-axis window scatter with `Mul` semantics.** The multi-axis window
   scatter switch only handled `Update` and `Add`; `Mul` fell through to
   `default` → `unsupported scatter update type for multi-dim slice update`.
3. **Mixed point-and-window scatter.** When a scatter mixes a point-scatter
   axis (collapsed via `inserted_window_dims`) with window-scatter axes
   (window extent > 1 on other scatter dims), the multi-axis window scatter
   `Add` precondition `insertedWindowDims.empty()` rejected it with
   `multi-dim window scatter Add requires empty insertedWindowDims and
   operand-rank updates`.

These were found when tying to run JAXFLUIDS on MPS via jax-mps.

## Minimal repros

```python
# JAX_PLATFORMS=mps python repro.py
import jax, jax.numpy as jnp
print("backend:", jax.default_backend())

# (1) General-point scatter, covered axis whose window slot is size 1
x = jnp.ones((2, 3, 4, 4), dtype=jnp.float32)
m = jnp.full((2, 3, 1, 4), 0.5, dtype=jnp.float32)
z = x.at[:, :, 0:1, :].mul(m); z.block_until_ready()
assert float(z[:, :, 0, :].mean()) == 0.5 and float(z[:, :, 1:, :].mean()) == 1.0

# (2) Multi-axis window scatter, Mul
x = jnp.ones((5, 5), dtype=jnp.float32)
u = jnp.full((2, 2), 0.5, dtype=jnp.float32)
z = x.at[1:3, 0:2].mul(u); z.block_until_ready()
assert float(z[1:3, 0:2].mean()) == 0.5

# (3) Mixed point-and-window scatter
x = jnp.zeros((5, 8, 8, 8), dtype=jnp.float32)
idx = jnp.array([1, 3])
u = jnp.full((2, 4, 4, 4), 1.0, dtype=jnp.float32)
z = x.at[idx, 1:5, 1:5, 1:5].add(u); z.block_until_ready()
assert float(z[idx, 1:5, 1:5, 1:5].sum()) == 2 * 4 * 4 * 4
assert float(z[0, ...].sum()) == 0.0
print("ok")
```

Before this PR each case raises a `[MPS ERROR]` and
`INTERNAL: Output count mismatch: expected 1, got 0`. With this PR all three
print `ok` and match CPU.

## Root cause (`src/pjrt_plugin/ops/gather_scatter.cc`)

The general-point scatter path builds `newShape` to reshape
`transposedUpdates` so each operand dim gets a slot — size 1 for "collapsed"
dims, real window size for "window" dims. The previous code partitioned
operand dims into
`coveredDims = inserted ∪ batching ∪ scatter_dims_to_operand_dims`
and pushed `1` for any covered dim, advancing `windowIdx` only for uncovered
dims.

That is correct for `inserted` and `batching` dims (no slot in `tShape`), but
wrong for dims in `scatter_dims_to_operand_dims` that are **not** also
inserted/batching: those *do* have a real entry in `tShape` (size 1 when the
scatter window is a single point, real window size otherwise). Conflating them
caused (1) the off-by-one when the slot was size 1 and (2) a structural
mismatch when the slot was > 1.

The correct discriminator is simply whether the dim has a slot in `tShape`.
Dims in `inserted_window_dims ∪ input_batching_dims` are collapsed (no slot →
push 1). Every other operand dim is a window dim (in `update_window_dims`),
has a slot in `tShape`, and should push that slot's value and advance
`windowIdx` — regardless of whether it is also a scatter axis.

With that corrected, the general path also handles the mixed point/window
case via MLX's `scatter_add` (per-axis indices broadcast to the update window
shape — see `mlx/ops.h` ~line 1129+). So fix (3) reduces to loosening one
dispatch condition so `hasWindowScatter && !insertedWindowDims.empty()` falls
through to the general path.

Fix (2) adds the missing `Mul` case in the multi-axis window scatter switch,
mirroring the existing `Add` case with `mlx::core::multiply`.

## Files changed

- `src/pjrt_plugin/ops/gather_scatter.cc` — three small changes in
  `HandleScatter`:
  - Loosen `if (hasWindowScatter)` → `if (hasWindowScatter &&
    insertedWindowDims.empty())` so mixed cases fall through to the general
    path.
  - Add `case ScatterType::Mul:` in the multi-axis window scatter switch
    (mirrors `case ScatterType::Add:`).
  - Replace the `coveredDims` partition in the general-point scatter
    `newShape` loop with the `insertedSet ∪ batchingSet` discriminator that
    consumes `tShape` slots uniformly for all window dims.
- `tests/configs/slice.py` — two regression entries:
  - `multi_axis_slice_scatter_mul_rank4` — rank-4 scatter with a covered axis
    whose window slot is size 1.
  - `mixed_point_window_scatter_add_rank4` — mixed point-and-window scatter
    add.

Net: ~10 lines C++ added, ~7 removed, plus the two test entries.

## Verification

- Apple M4, macOS 26.3, Python 3.13.5, jax/jaxlib 0.10.0; `jax-mps` `main`
  built from source at `09f4725` (current tip, post-`0.10.2` version bump).
- All three repros print `ok` under `JAX_PLATFORMS=mps` and match CPU.
- `CI=true pytest -q` → **2206 passed, 244 skipped, 32 xfailed**. The two new
  regression configs pass deterministically on both CPU and MPS. (One
  unrelated, pre-existing flake — `test_op_grad[numpyro.Gamma1-jit]`, a Gamma
  rejection-sampling gradient tolerance check — passes 3/3 in isolation and is
  independent of these changes.)

## Follow-up not addressed here

- The single-axis window scatter branch (`gather_scatter.cc` ~line 488+) has a
  similar shape and may benefit from the same dispatch simplification, but I
  don't have a repro that exercises it. Noting it for a possible later pass.
