### PR TITLE
fix(ops): work around jax 0.10.1 aval_to_ir_type signature change (#162)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -339,6 +339,10 @@ jobs:
     # about upstream-breaking patch releases (e.g. #162) before users do.
     # Informational only — does not block PRs.
     continue-on-error: true
+    # Disabled until an MPS-capable runner is available: the affected
+    # lowerings register only for platform="mps", so a CPU-only run would
+    # not actually exercise them. Re-enable by removing this `if: false`.
+    if: false
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -331,6 +331,40 @@ jobs:
           JAX_PLATFORMS: cpu
           JAX_TEST_MODE: cpu
 
+  test-jax-latest:
+    name: Test (jax/jaxlib latest)
+    needs: build
+    runs-on: macos-26
+    # Canary: install the newest jax/jaxlib allowed by pyproject so we learn
+    # about upstream-breaking patch releases (e.g. #162) before users do.
+    # Informational only — does not block PRs.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+
+      - name: Download wheel
+        uses: actions/download-artifact@v8
+        with:
+          name: wheel
+          path: dist/
+
+      - name: Install wheel and test dependencies (jax/jaxlib upgraded)
+        run: |
+          uv sync --all-groups --no-install-project --upgrade-package jax --upgrade-package jaxlib
+          uv pip install dist/*.whl
+          .venv/bin/python -c "import jax, jaxlib; print('jax', jax.__version__); print('jaxlib', jaxlib.__version__)"
+
+      - name: Run tests on CPU
+        run: .venv/bin/pytest tests/ -v
+        env:
+          JAX_PLATFORMS: cpu
+          JAX_TEST_MODE: cpu
+
   release:
     name: Release
     needs: [test, lint-cpp, lint-python]

--- a/src/jax_plugins/mps/ops.py
+++ b/src/jax_plugins/mps/ops.py
@@ -18,6 +18,18 @@ from jax._src.interpreters import mlir
 from jax._src.lax import lax as lax_lax
 from jax._src.lax import linalg as lax_linalg
 from jax._src.lax import special as lax_special
+from jax._src.lib.mlir import ir  # pyright: ignore[reportPrivateImportUsage]
+
+
+def _aval_to_ir_type(aval: core.ShapedArray) -> ir.Type:
+    """Construct an MLIR ranked-tensor type for a ShapedArray.
+
+    Avoids ``mlir.aval_to_ir_type`` whose signature is unstable across jax
+    patch releases (see issue #162); ``mlir.dtype_to_ir_type`` has been
+    signature-stable.
+    """
+    return ir.RankedTensorType.get(aval.shape, mlir.dtype_to_ir_type(aval.dtype))
+
 
 # ---------------------------------------------------------------------------
 # Scaled Dot-Product Attention (mps.sdpa)
@@ -48,7 +60,7 @@ _sdpa_p.def_impl(_sdpa_impl)
 
 
 def _sdpa_lowering(ctx, q, k, v, mask, *, scale):
-    result_type = mlir.aval_to_ir_type(ctx.avals_out[0])
+    result_type = _aval_to_ir_type(ctx.avals_out[0])
     return mlir.custom_call(
         call_target_name="mps.sdpa",
         result_types=[result_type],
@@ -79,7 +91,7 @@ _sdpa_causal_p.def_impl(_sdpa_causal_impl)
 
 
 def _sdpa_causal_lowering(ctx, q, k, v, *, scale):
-    result_type = mlir.aval_to_ir_type(ctx.avals_out[0])
+    result_type = _aval_to_ir_type(ctx.avals_out[0])
     return mlir.custom_call(
         call_target_name="mps.sdpa_causal",
         result_types=[result_type],
@@ -148,7 +160,7 @@ def _sdpa_bwd_lowering(ctx, q, k, v, mask, g, *, scale):
     avals = ctx.avals_out
     return mlir.custom_call(
         call_target_name="mps.sdpa_bwd",
-        result_types=[mlir.aval_to_ir_type(a) for a in avals],
+        result_types=[_aval_to_ir_type(a) for a in avals],
         operands=[q, k, v, mask, g],
         backend_config=f'{{"scale": {scale}}}',
     ).results
@@ -158,7 +170,7 @@ def _sdpa_causal_bwd_lowering(ctx, q, k, v, g, *, scale):
     avals = ctx.avals_out
     return mlir.custom_call(
         call_target_name="mps.sdpa_causal_bwd",
-        result_types=[mlir.aval_to_ir_type(a) for a in avals],
+        result_types=[_aval_to_ir_type(a) for a in avals],
         operands=[q, k, v, g],
         backend_config=f'{{"scale": {scale}}}',
     ).results
@@ -223,7 +235,7 @@ _rms_norm_p.def_impl(_rms_norm_impl)
 
 
 def _rms_norm_lowering(ctx, x, weight, *, eps):
-    result_type = mlir.aval_to_ir_type(ctx.avals_out[0])
+    result_type = _aval_to_ir_type(ctx.avals_out[0])
     return mlir.custom_call(
         call_target_name="mps.rms_norm",
         result_types=[result_type],
@@ -251,7 +263,7 @@ def _rms_norm_bwd_lowering(ctx, x, w, g, *, eps):
     avals = ctx.avals_out
     return mlir.custom_call(
         call_target_name="mps.rms_norm_bwd",
-        result_types=[mlir.aval_to_ir_type(a) for a in avals],
+        result_types=[_aval_to_ir_type(a) for a in avals],
         operands=[x, w, g],
         backend_config=f'{{"eps": {eps}}}',
     ).results
@@ -303,7 +315,7 @@ _layer_norm_p.def_impl(_layer_norm_impl)
 
 
 def _layer_norm_lowering(ctx, x, weight, bias, *, eps):
-    result_type = mlir.aval_to_ir_type(ctx.avals_out[0])
+    result_type = _aval_to_ir_type(ctx.avals_out[0])
     return mlir.custom_call(
         call_target_name="mps.layer_norm",
         result_types=[result_type],
@@ -332,7 +344,7 @@ def _layer_norm_bwd_lowering(ctx, x, w, b, g, *, eps):
     avals = ctx.avals_out
     return mlir.custom_call(
         call_target_name="mps.layer_norm_bwd",
-        result_types=[mlir.aval_to_ir_type(a) for a in avals],
+        result_types=[_aval_to_ir_type(a) for a in avals],
         operands=[x, w, b, g],
         backend_config=f'{{"eps": {eps}}}',
     ).results
@@ -398,7 +410,7 @@ _rope_p.def_impl(_rope_impl)
 
 
 def _rope_lowering(ctx, x, offset, *, dims, traditional, base, rope_scale):
-    result_type = mlir.aval_to_ir_type(ctx.avals_out[0])
+    result_type = _aval_to_ir_type(ctx.avals_out[0])
     traditional_str = "true" if traditional else "false"
     return mlir.custom_call(
         call_target_name="mps.rope",
@@ -434,7 +446,7 @@ _rope_bwd_p.def_impl(
 
 
 def _rope_bwd_lowering(ctx, x, offset, g, *, dims, traditional, base, rope_scale):
-    result_type = mlir.aval_to_ir_type(ctx.avals_out[0])
+    result_type = _aval_to_ir_type(ctx.avals_out[0])
     traditional_str = "true" if traditional else "false"
     return mlir.custom_call(
         call_target_name="mps.rope_bwd",
@@ -510,7 +522,7 @@ _gelu_p.def_impl(_gelu_impl_dispatch)
 
 
 def _gelu_lowering(ctx, x):
-    result_type = mlir.aval_to_ir_type(ctx.avals_out[0])
+    result_type = _aval_to_ir_type(ctx.avals_out[0])
     return mlir.custom_call(
         call_target_name="mps.gelu",
         result_types=[result_type],
@@ -526,7 +538,7 @@ _gelu_bwd_p.def_impl(lambda x, g: jax.vjp(lambda x: _gelu_impl_dispatch(x), x)[1
 
 
 def _gelu_bwd_lowering(ctx, x, g):
-    result_type = mlir.aval_to_ir_type(ctx.avals_out[0])
+    result_type = _aval_to_ir_type(ctx.avals_out[0])
     return mlir.custom_call(
         call_target_name="mps.gelu_bwd",
         result_types=[result_type],
@@ -575,8 +587,8 @@ def _eigh_lowering(
         raise NotImplementedError("algorithm selection not supported on MPS")
     del sort_eigenvalues  # kernel always sorts ascending
     v_aval, w_aval = ctx.avals_out
-    v_type = mlir.aval_to_ir_type(v_aval)
-    w_type = mlir.aval_to_ir_type(w_aval)
+    v_type = _aval_to_ir_type(v_aval)
+    w_type = _aval_to_ir_type(w_aval)
     return mlir.custom_call(
         call_target_name="mps.eigh",
         result_types=[v_type, w_type],
@@ -590,8 +602,8 @@ def _qr_lowering(ctx, operand, *, full_matrices, **kwargs):
     del kwargs  # pivoting, use_magma — not applicable on MPS
     # Result types from ctx.avals_out already reflect full_matrices setting.
     q_aval, r_aval = ctx.avals_out
-    q_type = mlir.aval_to_ir_type(q_aval)
-    r_type = mlir.aval_to_ir_type(r_aval)
+    q_type = _aval_to_ir_type(q_aval)
+    r_type = _aval_to_ir_type(r_aval)
     return mlir.custom_call(
         call_target_name="mps.qr",
         result_types=[q_type, r_type],
@@ -646,9 +658,9 @@ def _svd_lowering(
         return mlir.custom_call(
             call_target_name="mps.svd",
             result_types=[
-                mlir.aval_to_ir_type(s_aval),
-                mlir.aval_to_ir_type(u_aval),
-                mlir.aval_to_ir_type(vt_aval),
+                _aval_to_ir_type(s_aval),
+                _aval_to_ir_type(u_aval),
+                _aval_to_ir_type(vt_aval),
             ],
             operands=[operand],
             backend_config=f'{{"compute_uv": true, "full_matrices": {fm}}}',
@@ -657,7 +669,7 @@ def _svd_lowering(
         (s_aval,) = ctx.avals_out
         return mlir.custom_call(
             call_target_name="mps.svd",
-            result_types=[mlir.aval_to_ir_type(s_aval)],
+            result_types=[_aval_to_ir_type(s_aval)],
             operands=[operand],
             backend_config=f'{{"compute_uv": false, "full_matrices": {fm}}}',
         ).results
@@ -673,7 +685,7 @@ def _make_native_unary_lowering(call_target_name):
         (aval_out,) = ctx.avals_out
         return mlir.custom_call(
             call_target_name=call_target_name,
-            result_types=[mlir.aval_to_ir_type(aval_out)],
+            result_types=[_aval_to_ir_type(aval_out)],
             operands=[x],
             backend_config="",
         ).results

--- a/uv.lock
+++ b/uv.lock
@@ -473,7 +473,7 @@ wheels = [
 
 [[package]]
 name = "jax"
-version = "0.10.0"
+version = "0.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jaxlib" },
@@ -482,9 +482,9 @@ dependencies = [
     { name = "opt-einsum" },
     { name = "scipy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/50/f0/bcb81d28267d2054d0daed766c7fa16bcee5e481331b4d1e14f5fbe662be/jax-0.10.0.tar.gz", hash = "sha256:0119c767de1645f407df72345d28a3837dc904f1d698911c121d8f2b396fdece", size = 2663397, upload-time = "2026-04-22T13:22:28.563Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/49/b082387119c4a6bc7596296bbdc6bce034628cdd2845ebb27304cbca3624/jax-0.10.1.tar.gz", hash = "sha256:11672410faf8752429eb9a131de203dc488a2a3a012d509baa2b39878008810d", size = 2718178, upload-time = "2026-05-20T14:54:09.441Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/aa/dfac6d72cc35bc07e7587115b6946e333ef4ccb2e6cd26ecf639438c5d26/jax-0.10.0-py3-none-any.whl", hash = "sha256:76c42ba163c8db3dc2e449e225b888c0edfb623ded31efdc96d85e0fda1d26e8", size = 3094950, upload-time = "2026-04-16T12:32:11.576Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/6e/5087e0347188f6970aba1ffbd0018754d23c3f3461e9f21785f2f27a02c2/jax-0.10.1-py3-none-any.whl", hash = "sha256:47f3192c76e9e3358de1b106a8af5e943fccb10510903f25d96ea53652729134", size = 3150973, upload-time = "2026-05-20T14:51:30.066Z" },
 ]
 
 [[package]]
@@ -550,7 +550,7 @@ dev = [
 
 [[package]]
 name = "jaxlib"
-version = "0.10.0"
+version = "0.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ml-dtypes" },
@@ -558,28 +558,28 @@ dependencies = [
     { name = "scipy" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/5c/64a60f90d48bb6ab68ece63b7fa78855e8f8cefc4045f198a5c8695bfd99/jaxlib-0.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:277032e9f074c3fd5ffd1e0cb03d4fe66e272de472667cdbc418ad99b21b646a", size = 60115498, upload-time = "2026-04-16T12:33:15.93Z" },
-    { url = "https://files.pythonhosted.org/packages/71/bc/b75d9e09bcf46e00fd9cdd6c457219a8fe2033d351c2d133917662e8cbaa/jaxlib-0.10.0-cp311-cp311-manylinux_2_27_aarch64.whl", hash = "sha256:3db94ebc859375d955de3504182add7ce1733ce3d30c15e0ef031602cb51a559", size = 79395106, upload-time = "2026-04-16T12:33:19.648Z" },
-    { url = "https://files.pythonhosted.org/packages/64/13/a94b53b0acd3fccce0441e3811e86224e5b21ac122f2dea4be1ccdeb7dc0/jaxlib-0.10.0-cp311-cp311-manylinux_2_27_x86_64.whl", hash = "sha256:9be229993a41e5b2b84f234ecc19a5de02f35eddb1195cf027bd539e1601e15d", size = 85005588, upload-time = "2026-04-16T12:33:23.368Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/36/fbc303c0a41ac26daceeba0a9884d9206657e8eb1981f3f76da17f1ecc7f/jaxlib-0.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:421cdf3a4a5c2ee41471035e586954c8dc599d677ce9b11b063c3926a82a7850", size = 64195649, upload-time = "2026-04-16T12:33:26.972Z" },
-    { url = "https://files.pythonhosted.org/packages/79/0c/279cb4dc009fe87a8315d1b182f520693236ad07b852152df344ea4e4021/jaxlib-0.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7c1d9b463327c7a2333f210114ecb04f28fefc51ba8233a85a2280cce75bdb42", size = 60137156, upload-time = "2026-04-16T12:33:30.306Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/cd/59ead5a90df739d1b8c1d1d00443558fd30adf5abb0319966ce340d49ff3/jaxlib-0.10.0-cp312-cp312-manylinux_2_27_aarch64.whl", hash = "sha256:aa1d70f1a4e27eb403654e71e2fb28d5786d3e9b77fc1847e8c5389880927ca4", size = 79398938, upload-time = "2026-04-16T12:33:34.14Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/20/9b07fc8b327b222b6f72a4978eb4f2ebe856ee71237d63c4d808ec3945e0/jaxlib-0.10.0-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:b0bfb865a07df2e6d7418c0b0c292dd294b5500523b1dd5872b180db2aa480d4", size = 85028702, upload-time = "2026-04-16T12:33:37.815Z" },
-    { url = "https://files.pythonhosted.org/packages/08/3b/4f798fffed4229a2d7de07c1f4feabac7676a26c695a418796dbe29bae7f/jaxlib-0.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:25bf167e0d8b594e0ec50783ff4892c0b7ec37236c88b2b425a7c252823f8680", size = 64221923, upload-time = "2026-04-16T12:33:41.343Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/b6/b66b0abb9df8f9f8f19a5244b849cb07fc7389a4a5e1fb7794f7cefd7f26/jaxlib-0.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:384635fff55899a295bbc82ee6c6f773a300e787dc472ca92bbe79abfaac8369", size = 60138213, upload-time = "2026-04-16T12:33:45.13Z" },
-    { url = "https://files.pythonhosted.org/packages/30/1e/844e525a72a08a2744ae2722e2332a0159a6d0efdc1e561cf378f7259a01/jaxlib-0.10.0-cp313-cp313-manylinux_2_27_aarch64.whl", hash = "sha256:6d8d78b7070b34e4c5bba5f7e10927e7f4aac9b69be17e9b0a5898553a4338f3", size = 79401054, upload-time = "2026-04-16T12:33:49.263Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/95/305854c2ef2b645f7df1666be66b1167c392cc39384d09aca2e9499b71bf/jaxlib-0.10.0-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:d303dc31b65e8b793d5600f81b1583be03dc9b876a4c10b3e259b6609a1cbe3b", size = 85027218, upload-time = "2026-04-16T12:33:54.325Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/63/a5e1dcb65dca6efbae7189f185588fc939e17c284f272254fbeb68a39817/jaxlib-0.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:3869be623c2f3391be2ee86f8b412372b102492e67cac0a5f0ab1037bbc3a5cc", size = 64221972, upload-time = "2026-04-16T12:46:24.762Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/d6/411e580b70f64a5a4b095cb2c03c1e2c7b3b35c6754e5cacd4a8f8a2d480/jaxlib-0.10.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:9050ce2ae7eeca62b1a235065056cad62cac590ddc035486faa4472a47eed9f6", size = 60250897, upload-time = "2026-04-16T12:46:13.185Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/5c/f40ac9d40eb39c359f268e087ff1f21bdad664f86691c52a288d0f9152e8/jaxlib-0.10.0-cp313-cp313t-manylinux_2_27_aarch64.whl", hash = "sha256:59e07aab3bdfaad9bdd3cf32e0d3d4f228837b9b231c53f5ae1c0fc284481094", size = 79518774, upload-time = "2026-04-16T12:46:16.684Z" },
-    { url = "https://files.pythonhosted.org/packages/49/36/dea7a0ea64a5551244e2140ef6ad36e2dff308b6f5facaa6f1c1272bb47f/jaxlib-0.10.0-cp313-cp313t-manylinux_2_27_x86_64.whl", hash = "sha256:3088503812cfe49f34a3083d3b7ef5cb3aaf33d89ceb1b3f647fa52713aee59d", size = 85134776, upload-time = "2026-04-16T12:46:20.855Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/25/e1e52a21786b321fb6a2edf9ef9971aa70f06bb2738aef9afd6d8f46a441/jaxlib-0.10.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:98b26672943672742873f65bc03216819fc55325c99f146590d007c0172bff30", size = 60141273, upload-time = "2026-04-16T12:46:27.922Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/3b/21e3382ce6f4ee84bcce52810f3786ae3663991ec863acadcd0765b6f767/jaxlib-0.10.0-cp314-cp314-manylinux_2_27_aarch64.whl", hash = "sha256:ad47e072430979ec21637aa487d4dc464028b8e9be27268f37de69536c76e341", size = 79416404, upload-time = "2026-04-16T12:46:31.326Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/8e/b2a08ffc51c93842de71f7f988865cebfa7f43d6721957812dc8cc8b9d40/jaxlib-0.10.0-cp314-cp314-manylinux_2_27_x86_64.whl", hash = "sha256:2a42cf04c0f88bc03b150a17fa7ddbb2f40e096667ec8a1b840ed87913e6e735", size = 85035152, upload-time = "2026-04-16T12:46:36.129Z" },
-    { url = "https://files.pythonhosted.org/packages/24/08/26e6a3ecf0a95f1ec0dcd7a668d5c9a72e581c40fe4ae51e102ca63174c5/jaxlib-0.10.0-cp314-cp314-win_amd64.whl", hash = "sha256:450b771c01b3662c3497e2dceada3f6fc893112ae637ef85ef1dcc7dc68892a8", size = 66661443, upload-time = "2026-04-16T12:46:51.088Z" },
-    { url = "https://files.pythonhosted.org/packages/37/d7/06383d19217824134c4a6119d2efe7b53cde6a0a66fb1d643d9f725d2697/jaxlib-0.10.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f62026c9fb1f05998592082a6dcb62f70b466342bc139f711802a9b184ba9a46", size = 60253088, upload-time = "2026-04-16T12:46:39.666Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/ce/f66f955c01cce1ffda0cfbb1c02bb9234e0cac1d40b46fe17c315155d62f/jaxlib-0.10.0-cp314-cp314t-manylinux_2_27_aarch64.whl", hash = "sha256:e66bdc0b57ed5649950799d3f0d67a6bb67f03d06b49ea3fced0bdd6140a9943", size = 79517974, upload-time = "2026-04-16T12:46:43.147Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/74/b358923d0cce13fc7608051d0cc60ce3379f14350dc42540bdbabdbffab2/jaxlib-0.10.0-cp314-cp314t-manylinux_2_27_x86_64.whl", hash = "sha256:4dccd9065b30954879869641472d5d12fe4d7914175a5cad56293af8429ce7e0", size = 85134286, upload-time = "2026-04-16T12:46:47.416Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e9/43253041a0b28f64a99dfa8a6823de415b1b9723dc8eb8718945bb957b1c/jaxlib-0.10.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ff0c82cb958d180d26687459962e262b6e1c90f239903c8253cc190067124db4", size = 60802893, upload-time = "2026-05-20T14:52:36.047Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/dd/fe5e06087d79ef014a10fc4d5acba76f585278eb54cdbeb880347600a41c/jaxlib-0.10.1-cp311-cp311-manylinux_2_27_aarch64.whl", hash = "sha256:349b131c8b393fe5de2aabec1539f18c6a6ce85680b145c78b068fc56d498472", size = 80280956, upload-time = "2026-05-20T14:52:40.366Z" },
+    { url = "https://files.pythonhosted.org/packages/33/89/8c6dff28eaf86a917622e427caf045ecb85772eaa1679937915e4e5ac8d6/jaxlib-0.10.1-cp311-cp311-manylinux_2_27_x86_64.whl", hash = "sha256:9c2f0d6b910e93dd47bbfc3aa54c83950ff6a05955913892d31b034337d89420", size = 85810989, upload-time = "2026-05-20T14:52:45.208Z" },
+    { url = "https://files.pythonhosted.org/packages/83/fd/6b705478e19af3dd384351c91f4b469fef83bb1fa070c45a937ae7dcc335/jaxlib-0.10.1-cp311-cp311-win_amd64.whl", hash = "sha256:f49375e63c4486295e31d3f93b4abeb0a69183cb78484299b135c74bc036ec4c", size = 64802918, upload-time = "2026-05-20T14:52:49.279Z" },
+    { url = "https://files.pythonhosted.org/packages/53/b4/fdb6e989b142d8a8d2093f342cbc5323fe0d4a7217fd899c8ddf9e108a5a/jaxlib-0.10.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7a4399c7429c87ee6f7ab1e5712c5548ecfabde974ee9f4a12957fea4e35efb8", size = 60816137, upload-time = "2026-05-20T14:52:53.028Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/29/0b4eaaca005708751ff301903a2ca760dcc34175dadb7536498c57a7de85/jaxlib-0.10.1-cp312-cp312-manylinux_2_27_aarch64.whl", hash = "sha256:12126603ba472300c62480f86d20972d563143041039d9dea349ad510aa6123c", size = 80294034, upload-time = "2026-05-20T14:52:56.941Z" },
+    { url = "https://files.pythonhosted.org/packages/38/69/2912ab63036e21c72748019e1d8e09e8a1fc3368b3e83fc27898a1858575/jaxlib-0.10.1-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:f3cdf5b7f48470ab5455ab79aab746419694ccb6b52651cc2ce5fb27def03588", size = 85828774, upload-time = "2026-05-20T14:53:01.749Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/8f/993ea419eca6f34fe12613e22a03b93f40e5b1e8e0df18d4060e1313a1fc/jaxlib-0.10.1-cp312-cp312-win_amd64.whl", hash = "sha256:0acf3f8e7dca9074c0327f0f61502845792ca9f82fab23b841b00daa78e85488", size = 64830187, upload-time = "2026-05-20T14:53:05.932Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/76/3b637d4def229015a3035a7b44fac0dcf2536ae337540cdbffc651334d4e/jaxlib-0.10.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4167213aa00f14bb0d8fbd90f9ded75e976f71ce8baf8c3c44e04c8fb80ea0c1", size = 60815855, upload-time = "2026-05-20T14:53:11.718Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/76/9a1971bc9edb8728a7ba86d2693127ee46add9811230b8452321415fd4e9/jaxlib-0.10.1-cp313-cp313-manylinux_2_27_aarch64.whl", hash = "sha256:e53223d8f6861d33c02dd02343fa464700401ff5363784d37c33407218e328b8", size = 80293947, upload-time = "2026-05-20T14:53:15.408Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1d/69a0ba52fb546261e71a7209378ee6059950e9c088a2a18355e01509f474/jaxlib-0.10.1-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:bb073a1224e659e01e8d32d47c000edb52ec2aa8ba97ec22b2228b3a46e5c167", size = 85829861, upload-time = "2026-05-20T14:53:19.773Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/df/48659e2ee57705c63a51525f810fe3e0c87af4ca9f89d4738281a872d58e/jaxlib-0.10.1-cp313-cp313-win_amd64.whl", hash = "sha256:6449f1d4a22324f5f02c843360475783f9fd1d353fe711806cbf4e927d1360ae", size = 64828863, upload-time = "2026-05-20T14:53:24.562Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/34/3f7c95ee1b2555d611f836988a49b522c04b8d186e0528f91d45118089bf/jaxlib-0.10.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:72a7db1242d6b7773340e430c244e73a8d13f82ce83933c0529a8b4b1520dcf3", size = 60934063, upload-time = "2026-05-20T14:53:28.549Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/84/855a2395d299e00e1d9ffd0aecd516b52b81780f3e4ef537527be6d8c1fc/jaxlib-0.10.1-cp313-cp313t-manylinux_2_27_aarch64.whl", hash = "sha256:649c26ca92e9bbffb3c35226b37893916f20e6b89fb3911ce79b39e5cfb27b46", size = 80402500, upload-time = "2026-05-20T14:53:32.444Z" },
+    { url = "https://files.pythonhosted.org/packages/be/35/153e91a9c770a981d525d845b3f4cdb71a1e119681594a33908e9536bdff/jaxlib-0.10.1-cp313-cp313t-manylinux_2_27_x86_64.whl", hash = "sha256:cfe75d8a17e0d33a7bed27f32d7a5344a66e8d4af7073973f396e14ff4a9c503", size = 85941210, upload-time = "2026-05-20T14:53:36.982Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/a1/c4d4c0530313c50dd1ba07fff480cfd0c5f18c5ec49742f4a52a6edfd95f/jaxlib-0.10.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9a657554dbe56f3691d377cb99d00b29df14e5638e579e57965f9f69c32c9315", size = 60826189, upload-time = "2026-05-20T14:53:40.73Z" },
+    { url = "https://files.pythonhosted.org/packages/98/71/529b2439b88491e0806ee9fa6191ecf90f4447dfe092e80bd19577c85260/jaxlib-0.10.1-cp314-cp314-manylinux_2_27_aarch64.whl", hash = "sha256:93cd9989404f86a21b50c7ff4e850a31f55509664312080978bde97a664d92a9", size = 80300654, upload-time = "2026-05-20T14:53:44.751Z" },
+    { url = "https://files.pythonhosted.org/packages/be/08/0bc4132fb2fe224ee9d83fd60e3650fd4d893b4e5148707a98df8f0333a4/jaxlib-0.10.1-cp314-cp314-manylinux_2_27_x86_64.whl", hash = "sha256:26b94e9640b01968cc14b8353dd6b6540d723f30579c78b1f46a477fc4aa196d", size = 85841241, upload-time = "2026-05-20T14:53:49.13Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/de/423d748ce3367bd5ea20d8cc34a7ceb6420da4d41c20b247f54194700d04/jaxlib-0.10.1-cp314-cp314-win_amd64.whl", hash = "sha256:375820799bbf7d515dd4e4d40f3334566b73d3fe64d340afbd6aa897d5d7c486", size = 67301520, upload-time = "2026-05-20T14:53:52.989Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/bf/3f7ce089d62f7ac85ea678925471f7ec88038899e67ab02079c1e7d8ad4e/jaxlib-0.10.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:bc52f16bdd61b299efeed7ea8e743e91a118059a463da2ab97196fc05b69ddb7", size = 60935393, upload-time = "2026-05-20T14:53:56.886Z" },
+    { url = "https://files.pythonhosted.org/packages/65/6a/38cf1d4ff8c8f74ec8d567e0aa6e3d2082ab6fc580545f6bb51368da20a9/jaxlib-0.10.1-cp314-cp314t-manylinux_2_27_aarch64.whl", hash = "sha256:55b0a473fbd57d31dc3935c4cd5c0c38af5f7c1f41300df27923cf46676972ca", size = 80405741, upload-time = "2026-05-20T14:54:01.94Z" },
+    { url = "https://files.pythonhosted.org/packages/16/9e/d3cff171aaf13a09aab26a44d1a27dcbf0d6311e4d855f5d99685965ace3/jaxlib-0.10.1-cp314-cp314t-manylinux_2_27_x86_64.whl", hash = "sha256:4b0cb8ef960a3723037db63f28ffa20083d90fff6d30085e99d7c63cfa08e4c0", size = 85942183, upload-time = "2026-05-20T14:54:05.91Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Fixes #162: `jax 0.10.1` changed `mlir.aval_to_ir_type` to require a `ModuleContext` as the first positional arg, which broke all 21 call sites in `src/jax_plugins/mps/ops.py` with `TypeError: aval_to_ir_type() missing 1 required positional argument: 'aval'`.
- Replace those calls with a local `_aval_to_ir_type(aval)` helper that builds the `RankedTensorType` directly via `mlir.dtype_to_ir_type` (signature-stable across `0.10.0` and `0.10.1`). Works under both jax versions, no signature shim needed.
- Bump `uv.lock` to `jax/jaxlib 0.10.1`.
- Add a `test-jax-latest` CI job that resolves jax/jaxlib to the newest version allowed by `pyproject` before running pytest, marked `continue-on-error: true` so it acts as an early warning canary without blocking PRs. Gated with `if: false` for now — the affected lowerings register only for `platform="mps"`, so a CPU-only run on the current GitHub runners would not exercise them. Flip the `if: false` once an MPS-capable runner is available.

## Test plan

- [x] `uv sync --upgrade-package jax --upgrade-package jaxlib` (resolved to `0.10.1`)
- [x] Issue #162 repro (`jax.random.normal(..., dtype=jnp.bfloat16)`) succeeds
- [x] Full suite passes locally on `jax 0.10.1`: 2199 passed, 244 skipped, 32 xfailed
- [x] Pre-commit (`ruff format`, `ruff check`, `pyright`, `pytest`) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)