### PR TITLE
ci: skip build/pyright/pytest hooks for workflow-only changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,13 +27,13 @@ repos:
         entry: bash -c 'uv run pyright'
         language: system
         pass_filenames: false
-        always_run: true
+        exclude: ^\.github/workflows/
       - id: build
         name: build
         entry: bash -c 'uv pip install -e . -q'
         language: system
         pass_filenames: false
-        always_run: true
+        exclude: ^\.github/workflows/
       - id: clang-tidy
         name: clang-tidy
         entry: |
@@ -52,4 +52,4 @@ repos:
         entry: bash -c 'CI=true uv run pytest -q'
         language: system
         pass_filenames: false
-        always_run: true
+        exclude: ^\.github/workflows/


### PR DESCRIPTION
## Summary

The `build`, `pyright`, and `pytest` pre-commit hooks used `always_run: true`, so they fired on **every** commit regardless of what changed — including commits that only edit GitHub Actions workflow files.

This replaces `always_run: true` with `exclude: ^\.github/workflows/` on those three hooks. With `always_run` gone, pre-commit only runs a hook when at least one staged file is included; the default `files` pattern matches everything, and the new `exclude` drops anything under `.github/workflows/`.

Net effect:
- A commit touching **only** workflow files → build / pyright / pytest are skipped.
- A commit touching any other file → all hooks run as before.

## Test plan

- Verified the commit creating this change still ran build, pyright, and pytest (config file is not a workflow file) — all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)