### PR TITLE
ci: pin wheel platform tag to macOS 13.0 deployment target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,6 +150,11 @@ jobs:
       - name: Build wheel
         run: uv build --wheel
         env:
+          # Pin the wheel's platform tag (macosx_13_0_arm64) to the deployment
+          # target instead of letting scikit-build-core track the runner OS.
+          # Without this, the macos-26 runner tags wheels macosx_26_0, locking
+          # out older macOS. Keep in sync with CMAKE_OSX_DEPLOYMENT_TARGET.
+          MACOSX_DEPLOYMENT_TARGET: "13.0"
           CMAKE_ARGS: "-DCMAKE_PREFIX_PATH=${{ github.workspace }}/.jax-mps-deps/llvm;${{ github.workspace }}/.jax-mps-deps/protobuf;${{ github.workspace }}/.jax-mps-deps/mlx"
 
       - name: Upload wheel
@@ -283,6 +288,8 @@ jobs:
           sed -i '' "s/^version = \".*\"/version = \"$DEV_VERSION\"/" pyproject.toml
           uv build --wheel
         env:
+          # See "Build wheel" above: pin platform tag to the deployment target.
+          MACOSX_DEPLOYMENT_TARGET: "13.0"
           CMAKE_ARGS: "-DCMAKE_PREFIX_PATH=${{ github.workspace }}/.jax-mps-deps/llvm;${{ github.workspace }}/.jax-mps-deps/protobuf;${{ github.workspace }}/.jax-mps-deps/mlx"
 
       - name: Upload dev wheel


### PR DESCRIPTION
## Summary

Wheels stopped installing on macOS 15 (and 14) as of v0.10.2 — `uv`/`pip` see only `macosx_26_0_arm64` wheels. Fixes #166.

## Root cause

The `runs-on:` bump from `macos-14` → `macos-26` in #153 was deliberate and correct: macos-14's older SDK silently hid MLX v0.31.2's `jaccl::jaccl` `find_package(MLX)` break on SDK ≥ 26.2, which that PR exposed and patched out. **That part stays.**

The side effect was unintended: this project builds with `scikit-build-core`, which tags the wheel with the **runner's** macOS version when `MACOSX_DEPLOYMENT_TARGET` is unset. So the wheel tag rode the runner bump from `macosx_14_0` → `macosx_26_0`, raising the install floor to macOS 26. PyPI confirms the cutover lands exactly on #153's merge (2026-05-12). The C++ was already compiled for an older floor (`CMAKE_OSX_DEPLOYMENT_TARGET "13.0"`), so the two had silently drifted apart.

## Fix

Set `MACOSX_DEPLOYMENT_TARGET=13.0` in both wheel-build steps (`Build wheel`, `Build dev wheel`). scikit-build-core then pins the platform tag to the deployment target (`macosx_13_0_arm64`, installable on macOS 13+) independent of the runner OS, and passes it through to CMake. Matches the existing `CMAKE_OSX_DEPLOYMENT_TARGET`. Runner stays on macos-26 and the jaccl patch is untouched.

## Test plan

- [ ] On next push to `main`, confirm the `build-dev` job publishes a wheel tagged `cp3xx-macosx_13_0_arm64` (not `macosx_26_0`).
- Note: takes effect on the next build; a new release must be cut to unblock the reporter. CI can't runtime-verify install on macOS 13–15 (no GPU runners), but the deployment target only weak-links newer SDK symbols, standard practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)