### PR TITLE
Fix intermittent wrong LayerNorm bias gradient (MLX Metal WAR hazard)

### DIFF
--- a/third_party/mlx/patches/10-layernorm-vjp-bias-war-hazard.patch
+++ b/third_party/mlx/patches/10-layernorm-vjp-bias-war-hazard.patch
@@ -1,0 +1,27 @@
+Fix an intermittent wrong bias gradient from fast::layer_norm on Metal.
+
+LayerNormVJP::eval_gpu reduces the cotangent `g` into the bias gradient `gb`
+and then dispatches the vjp kernel, which overwrites `g`'s buffer in place when
+the cotangent is donated (gx or gw_temp alias g). The gb reduction reads g and
+the kernel writes that same buffer — a write-after-read hazard. The Metal
+CommandEncoder only auto-inserts barriers for read-after-write, so the two
+dispatches race and gb is intermittently wrong (~5-15%, off by ~100%). The x and
+weight gradients are unaffected. Insert an explicit barrier after the gb
+reduction. Reproduces on MLX v0.31.2 and main; report upstream.
+
+diff --git a/mlx/backend/metal/normalization.cpp b/mlx/backend/metal/normalization.cpp
+index 9a222cd..98c2257 100644
+--- a/mlx/backend/metal/normalization.cpp
++++ b/mlx/backend/metal/normalization.cpp
+@@ -367,6 +367,11 @@ void LayerNormVJP::eval_gpu(
+         ReductionOpType::ContiguousStridedReduce, {n_rows}, {axis_size});
+     strided_reduce_general_dispatch(
+         g, gb, "sum", plan, {0}, compute_encoder, d, s);
++    // The gb reduction reads `g`. The vjp kernel below overwrites `g`'s buffer
++    // when the cotangent is donated (gx or gw_temp may alias g). That is a
++    // write-after-read hazard, which the command encoder's automatic barrier
++    // logic (read-after-write only) does not cover, so insert one explicitly.
++    compute_encoder.barrier();
+   }
+ 
+   int simd_size = 32;


### PR DESCRIPTION
## Summary
Adds MLX patch `10-layernorm-vjp-bias-war-hazard.patch`, fixing an intermittent **wrong bias gradient** from `fast::layer_norm` on the Metal GPU.

## Root cause
`LayerNormVJP::eval_gpu` (`mlx/backend/metal/normalization.cpp`) reduces the cotangent `g` into the bias gradient `gb`, then dispatches the vjp kernel — which overwrites `g`'s buffer **in place** when the cotangent is donated (`gx`/`gw_temp` alias `g`). The `gb` reduction reads `g` while the kernel writes it: a **write-after-read hazard**. MLX's Metal `CommandEncoder` only auto-inserts barriers for *read-after-write*, so the two dispatches race and `gb` is intermittently wrong (~5–15% of evaluations, off by ~100%). The input and weight gradients are unaffected. The patch adds an explicit `compute_encoder.barrier()` after the `gb` reduction.

## Why it started failing recently
This is a **latent MLX bug** — it reproduces in pure eager MLX on both v0.31.0 and `main`. jax-mps exercised this path for ~6 weeks on jax 0.9 with green CI; it only began manifesting after the **jax 0.10 bump (#144)**, whose buffer donation newly satisfies the hazard's precondition. So this is environment drift exposing an old bug, not a regression here.

## Verification
- Standalone MRE: **108/2000 wrong → 0/3000** with the patch.
- Through the plugin: layer-norm grad tests pass; `d/db` 0/2000.
- Patch applies cleanly to vanilla v0.31.2 and coexists with the existing patches.

Upstream repro (to be filed with ml-explore/mlx): https://gist.github.com/tillahoffmann/0ce6b748d7249da10962e4aad4155bcd

## Not covered
Other intermittent numpyro grad failures (e.g. `Gamma`, `NegativeBinomial2`) are **separate** latent MLX kernel bugs similarly exposed by jax 0.10. They are not addressed here, so CI may still fail intermittently on those until they're fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)