### PR TITLE
fix: inline func.calls and bitcast non-finite constants (#170)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,7 @@ add_library(pjrt_plugin_passes STATIC
     src/pjrt_plugin/passes/mps_fusion_pass.cc
     src/pjrt_plugin/passes/fuse_bias_add.cc
     src/pjrt_plugin/passes/fuse_softmax.cc
+    src/pjrt_plugin/passes/stablehlo_inliner_interface.cc
 )
 set_target_properties(pjrt_plugin_passes PROPERTIES
     POSITION_INDEPENDENT_CODE ON
@@ -192,6 +193,7 @@ set(MLIR_LIBS
     MLIRTransforms
     MLIRFuncDialect
     MLIRFuncTransforms
+    MLIRFuncInlinerExtension
     MLIRArithDialect
     MLIRComplexDialect
     MLIRQuantDialect

--- a/src/pjrt_plugin/mlx_executable.cc
+++ b/src/pjrt_plugin/mlx_executable.cc
@@ -9,9 +9,11 @@
 #include <chrono>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <functional>
 #include <stdexcept>
 #include <unordered_map>
+#include <vector>
 
 #include "llvm/Support/raw_ostream.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -103,6 +105,55 @@ std::optional<mlx::core::array> CreateArrayWithTypedPtr(const void* data,
     }
 }
 
+// jax-mps#170: a non-finite float constant (the NaN/inf guard that jnp.std/var
+// and numpyro grads bake in) materialized as a plain leaf array becomes a
+// never-written buffer under mlx::core::compile(), so the compiled kernel reads
+// garbage (intermittent zero / wrong gradients). Materialize such constants
+// instead via a bitcast of their integer bit-pattern: that is a *computed* value
+// (written by a kernel before it is read) and compiles correctly. Returns
+// nullopt for finite values / non-float dtypes so callers use the normal copy
+// path. `numElements` is the number of float elements addressable at `data`
+// (1 for a splat). `data` (DenseElementsAttr::getRawData()) is byte-oriented and
+// not guaranteed to be element-aligned, so the bytes are memcpy'd into aligned
+// storage before being read as integers.
+std::optional<mlx::core::array> MaybeBitcastNonFiniteFloat(const void* data,
+                                                           const mlx::core::Shape& shape,
+                                                           mlx::core::Dtype dtype,
+                                                           size_t numElements) {
+    // Non-finite (inf/nan) iff the exponent field is all ones.
+    if (dtype == mlx::core::float32) {
+        std::vector<uint32_t> bits(numElements);
+        std::memcpy(bits.data(), data, numElements * sizeof(uint32_t));
+        bool nonFinite = false;
+        for (uint32_t b : bits) {
+            if ((b & 0x7F800000U) == 0x7F800000U) {
+                nonFinite = true;
+                break;
+            }
+        }
+        if (!nonFinite)
+            return std::nullopt;
+        return mlx::core::view(mlx::core::array(bits.data(), shape, mlx::core::uint32),
+                               mlx::core::float32);
+    }
+    if (dtype == mlx::core::float16 || dtype == mlx::core::bfloat16) {
+        const uint16_t expMask = dtype == mlx::core::float16 ? 0x7C00U : 0x7F80U;
+        std::vector<uint16_t> bits(numElements);
+        std::memcpy(bits.data(), data, numElements * sizeof(uint16_t));
+        bool nonFinite = false;
+        for (uint16_t b : bits) {
+            if ((b & expMask) == expMask) {
+                nonFinite = true;
+                break;
+            }
+        }
+        if (!nonFinite)
+            return std::nullopt;
+        return mlx::core::view(mlx::core::array(bits.data(), shape, mlx::core::uint16), dtype);
+    }
+    return std::nullopt;
+}
+
 std::optional<mlx::core::array> CreateArrayFromDenseAttr(mlir::DenseElementsAttr attr) {
     auto tensorType = mlir::dyn_cast<mlir::RankedTensorType>(attr.getType());
     if (!tensorType) {
@@ -117,7 +168,10 @@ std::optional<mlx::core::array> CreateArrayFromDenseAttr(mlir::DenseElementsAttr
 
     // Handle splat constants (single value broadcast to shape)
     if (attr.isSplat()) {
-        auto scalar_opt = CreateArrayWithTypedPtr(rawData.data(), {}, mlxDtype);
+        // jax-mps#170: route non-finite floats through a bitcast (computed value).
+        auto scalar_opt = MaybeBitcastNonFiniteFloat(rawData.data(), {}, mlxDtype, 1);
+        if (!scalar_opt)
+            scalar_opt = CreateArrayWithTypedPtr(rawData.data(), {}, mlxDtype);
         if (!scalar_opt) {
             MPS_LOG_ERROR("Unsupported dtype %d for splat constant\n",
                           static_cast<int>(static_cast<mlx::core::Dtype::Val>(mlxDtype)));
@@ -171,7 +225,10 @@ std::optional<mlx::core::array> CreateArrayFromDenseAttr(mlir::DenseElementsAttr
         return std::nullopt;
     }
 
-    auto result = CreateArrayWithTypedPtr(rawData.data(), shape, mlxDtype);
+    // jax-mps#170: route non-finite floats through a bitcast (computed value).
+    auto result = MaybeBitcastNonFiniteFloat(rawData.data(), shape, mlxDtype, numElements);
+    if (!result)
+        result = CreateArrayWithTypedPtr(rawData.data(), shape, mlxDtype);
     if (!result) {
         MPS_LOG_ERROR("Unsupported dtype %d for constant\n",
                       static_cast<int>(static_cast<mlx::core::Dtype::Val>(mlxDtype)));
@@ -602,7 +659,10 @@ MlxExecuteResult MlxExecutable::Execute(const std::vector<MlxBuffer*>& inputs) {
 
     static bool disable_compile = std::getenv("MPS_NO_COMPILE") != nullptr;
     {
-        if (!compile_attempted_ && !disable_compile) {
+        // Safety net: if a func.call survived inlining (a multi-block / control-
+        // flow callee the inliner can't clone), use the eager path instead of
+        // compile() (jax-mps#170). Single-block callees are inlined and compile.
+        if (!compile_attempted_ && !disable_compile && !parsed_module_.has_uninlined_call) {
             compile_attempted_ = true;
 
             auto exec_fn =

--- a/src/pjrt_plugin/passes/stablehlo_inliner_interface.cc
+++ b/src/pjrt_plugin/passes/stablehlo_inliner_interface.cc
@@ -1,0 +1,48 @@
+// Permissive StableHLO/CHLO inliner interface. Compiled -fno-rtti (see this
+// directory's CMake target) so it matches MLIR's build and does not reference
+// `typeinfo for mlir::DialectInterface`.
+
+#include "pjrt_plugin/passes/stablehlo_inliner_interface.h"
+
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Transforms/InliningUtils.h"
+#include "stablehlo/dialect/ChloOps.h"
+#include "stablehlo/dialect/StablehloOps.h"
+
+namespace mps {
+namespace {
+
+// All StableHLO/CHLO ops are legal to inline. The func dialect's own inliner
+// interface handles the func.call/func.return mechanics (argument and result
+// mapping, terminator handling); this interface only tells the inliner that the
+// callee body ops may be cloned into the caller.
+struct PermissiveInlinerInterface : public mlir::DialectInlinerInterface {
+    using mlir::DialectInlinerInterface::DialectInlinerInterface;
+
+    bool isLegalToInline(mlir::Operation* /*op*/, mlir::Region* /*dest*/, bool /*wouldBeCloned*/,
+                         mlir::IRMapping& /*valueMapping*/) const final {
+        return true;
+    }
+    bool isLegalToInline(mlir::Region* /*dest*/, mlir::Region* /*src*/, bool /*wouldBeCloned*/,
+                         mlir::IRMapping& /*valueMapping*/) const final {
+        return true;
+    }
+    bool isLegalToInline(mlir::Operation* /*call*/, mlir::Operation* /*callable*/,
+                         bool /*wouldBeCloned*/) const final {
+        return true;
+    }
+};
+
+}  // namespace
+
+void registerStablehloInlinerInterfaces(mlir::MLIRContext& context) {
+    if (auto* d = context.getLoadedDialect<mlir::stablehlo::StablehloDialect>()) {
+        d->addInterfaces<PermissiveInlinerInterface>();
+    }
+    if (auto* d = context.getLoadedDialect<mlir::chlo::ChloDialect>()) {
+        d->addInterfaces<PermissiveInlinerInterface>();
+    }
+}
+
+}  // namespace mps

--- a/src/pjrt_plugin/passes/stablehlo_inliner_interface.h
+++ b/src/pjrt_plugin/passes/stablehlo_inliner_interface.h
@@ -1,0 +1,24 @@
+#ifndef PJRT_PLUGIN_PASSES_STABLEHLO_INLINER_INTERFACE_H
+#define PJRT_PLUGIN_PASSES_STABLEHLO_INLINER_INTERFACE_H
+
+namespace mlir {
+class MLIRContext;
+}  // namespace mlir
+
+namespace mps {
+
+// Register a permissive DialectInlinerInterface on the StableHLO and CHLO
+// dialects loaded in `context`, so MLIR's inliner can inline func.call ops whose
+// callee bodies contain StableHLO/CHLO ops (jnp.std/var/numpyro lower their guard
+// `where` to func.call @_where, etc.). Without an inliner interface the stock
+// inliner cannot prove those ops are legal to inline and silently no-ops.
+//
+// This is defined in the -fno-rtti pass translation unit on purpose: MLIR is
+// built -fno-rtti and never emits `typeinfo for mlir::DialectInterface`, so a
+// subclass compiled with RTTI fails to link (undefined typeinfo). Call after the
+// dialects are loaded into the context.
+void registerStablehloInlinerInterfaces(mlir::MLIRContext& context);
+
+}  // namespace mps
+
+#endif  // PJRT_PLUGIN_PASSES_STABLEHLO_INLINER_INTERFACE_H

--- a/src/pjrt_plugin/stablehlo_parser.cc
+++ b/src/pjrt_plugin/stablehlo_parser.cc
@@ -15,6 +15,7 @@
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/raw_ostream.h"
 #include "mlir/Bytecode/BytecodeReader.h"
+#include "mlir/Dialect/Func/Extensions/InlinerExtension.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/MLIRContext.h"
@@ -25,6 +26,7 @@
 #include "pjrt_plugin/logging.h"
 #include "pjrt_plugin/ops/registry.h"
 #include "pjrt_plugin/passes/mps_fusion_pass.h"
+#include "pjrt_plugin/passes/stablehlo_inliner_interface.h"
 #include "stablehlo/dialect/ChloOps.h"
 #include "stablehlo/dialect/Serialization.h"
 #include "stablehlo/dialect/StablehloOps.h"
@@ -59,8 +61,15 @@ void registerDialects(mlir::MLIRContext& context) {
     registry.insert<mlir::stablehlo::StablehloDialect>();
     registry.insert<mlir::vhlo::VhloDialect>();
     registry.insert<mlir::chlo::ChloDialect>();
+    // The func dialect's inliner interface (which makes func.call inlinable) lives
+    // in a separate extension; without it MLIR's inliner cannot inline any call.
+    mlir::func::registerInlinerExtension(registry);
     context.appendDialectRegistry(registry);
     context.loadAllAvailableDialects();
+    // Teach the inliner that StableHLO/CHLO ops are inlinable too, so it can
+    // inline func.call ops whose bodies are those ops (jnp.std/var/numpyro lower
+    // their guard `where` to func.call @_where).
+    registerStablehloInlinerInterfaces(context);
     // Allow unknown dialects (e.g., sdy/Shardy for sharding) to pass through
     context.allowUnregisteredDialects();
 }
@@ -93,21 +102,30 @@ bool runOptimizationPasses(mlir::MLIRContext& context, mlir::ModuleOp module) {
     return true;
 }
 
-// Run the inliner pass to inline all func.call operations
+// Inline func.call operations with MLIR's stock inliner. Two interfaces enable
+// this (both registered in registerDialects): the func dialect's inliner
+// extension makes func.call inlinable, and registerStablehloInlinerInterfaces
+// makes StableHLO/CHLO ops inlinable. Together they let the inliner inline the
+// guard `where` that jnp.std/var/numpyro lower to a func.call @_where; non-finite
+// guard constants are materialized safely (see MaybeBitcastNonFiniteFloat) so the
+// inlined grads compile correctly (jax-mps#170). Any call the inliner leaves in
+// place is detected in finalizeModule and routed to the eager path.
 bool runInlinerPass(mlir::MLIRContext& context, mlir::ModuleOp module) {
-    // Mark all non-main functions as private so they can be inlined
-    // The MLIR inliner only inlines private functions by default
+    // The inliner only inlines (and then dead-function-eliminates) private
+    // callees; jaxlib emits the helpers as public, so mark them private first.
     module.walk([&](mlir::func::FuncOp funcOp) {
         if (funcOp.getName() != "main" && funcOp.isPublic()) {
             funcOp.setPrivate();
         }
     });
 
-    // Run a single inliner pass - we handle remaining func.call at runtime
     mlir::PassManager pm(&context);
     pm.addPass(mlir::createInlinerPass());
+    // Drop now-dead private callees so the has_uninlined_call scan in
+    // finalizeModule only sees func.calls that are actually reachable (a
+    // func.call left in a dead function would otherwise needlessly force eager).
+    pm.addPass(mlir::createSymbolDCEPass());
 
-    // If inliner fails, log but continue - we handle func.call at runtime
     if (mlir::failed(pm.run(module))) {
         MPS_LOG_DEBUG("Inliner pass failed, func.call ops will be handled at runtime\n");
     }
@@ -205,6 +223,16 @@ ParsedModule finalizeModule(std::unique_ptr<mlir::MLIRContext> context,
 
     // Check for unsupported operations across ALL functions in the module
     result.unsupported_ops = checkUnsupportedOps(*module);
+
+    // Detect any func.call that survived inlining (a multi-block callee the
+    // inliner could not clone). Flag it so the executable uses the eager path as
+    // a safety net rather than compile() (jax-mps#170).
+    module->walk([&](mlir::func::CallOp) { result.has_uninlined_call = true; });
+    if (result.has_uninlined_call) {
+        MPS_LOG_WARN(
+            "func.call survived inlining; forcing eager path (no compile) to "
+            "avoid jax-mps#170 miscompile\n");
+    }
 
     // Transfer ownership
     result.context = std::move(context);

--- a/src/pjrt_plugin/stablehlo_parser.h
+++ b/src/pjrt_plugin/stablehlo_parser.h
@@ -22,6 +22,14 @@ struct ParsedModule {
     // List of unsupported operations encountered during parsing
     std::vector<std::string> unsupported_ops;
 
+    // True if a reachable func.call survived inlining (e.g. a recursive or
+    // otherwise non-inlinable callee). Such calls run via HandleCall, whose
+    // compile() lowering is unsafe (jax-mps#170), so the executable falls back to
+    // the eager path for them. Usually false: MLIR's inliner inlines the helper
+    // calls jaxlib emits (jnp.std/var/numpyro @_where, ...) and SymbolDCE drops
+    // the dead callees, so this flag flips true only for the rare residual call.
+    bool has_uninlined_call = false;
+
     // Check if parsing was successful
     bool ok() const {
         return context && module && entry_func;

--- a/tests/configs/numpyro.py
+++ b/tests/configs/numpyro.py
@@ -40,9 +40,6 @@ def make_numpyro_op_configs():
                     dists.Gamma,
                     lambda key, bs=batch_shape: random.gamma(key, 5.0, bs),
                     lambda key, bs=batch_shape: random.gamma(key, 5.0, bs),
-                    # Intermittent fused-reduction grad race, tracked in #170.
-                    grad_xfail="Values are not close",
-                    grad_xfail_strict=False,
                 ),
                 NumpyroDistributionTestConfig(
                     dists.Exponential,
@@ -137,9 +134,6 @@ def make_numpyro_op_configs():
                         key, 5.0, bs
                     ),  # concentration
                     differentiable_argnums=(1, 2),
-                    # Intermittent fused-reduction grad race, tracked in #170.
-                    grad_xfail="Values are not close",
-                    grad_xfail_strict=False,
                 ),
                 NumpyroDistributionTestConfig(
                     dists.MultinomialProbs,
@@ -181,9 +175,6 @@ def make_numpyro_op_configs():
                         key, 5.0, bs
                     ),  # concentration
                     lambda key, bs=batch_shape: random.gamma(key, 5.0, bs),  # rate
-                    # Same digamma-based fused-reduction grad race as Gamma (#170).
-                    grad_xfail="Values are not close",
-                    grad_xfail_strict=False,
                 ),
                 NumpyroDistributionTestConfig(
                     dists.VonMises,

--- a/tests/configs/reduction.py
+++ b/tests/configs/reduction.py
@@ -10,22 +10,12 @@ def make_reduction_op_configs():
             "reduction-complex" if complex else "reduction-real"
         ):
             for reduction in [jnp.sum, jnp.mean, jnp.var, jnp.std]:
-                # std's fused VJP intermittently miscompiles under MLX's
-                # untracked-resource model (a resource-level race in compile(),
-                # tracked in github.com/tillahoffmann/jax-mps#170). Non-strict
-                # xfail so the test may pass (xpass) or fail (xfail) cleanly.
-                std_xfail = (
-                    {"grad_xfail": "Values are not close", "grad_xfail_strict": False}
-                    if reduction is jnp.std
-                    else {}
-                )
                 yield from [
                     OperationTestConfig(
                         reduction,
                         lambda key, complex=complex: complex_standard_normal(
                             key, (4, 8), complex
                         ),
-                        **std_xfail,
                     ),
                     # Explicit argument because capture doesn't work.
                     OperationTestConfig(


### PR DESCRIPTION
## Summary

Fixes #170 — the intermittent all-zero / NaN gradient on `jnp.std`/`var` and several numpyro distribution grads. Root-cause fix: the affected grads now **compile and fuse** correctly.

## Root cause

`jnp.std`/`var`/numpyro grads lower their guard `where(n>0, var, NaN)` to a StableHLO `func.call @_where`. Two issues combined to miscompile them under `mlx::core::compile()`:

1. **The NaN guard constant** was materialized as a plain leaf array. Once MLX fused the scalar factor chain into a single `Compiled` kernel, that constant became a **never-written buffer** → the gradient came back all-zero / NaN (deterministic on the first GPU op; ~25% on full-suite runs from recycled buffers). Pure `mlx.core` compiles the *identical* op graph correctly when the NaN is a written value, so the defect is in how jax-mps materializes the constant — **not in MLX**.
2. **The `func.call` was never inlined.** MLIR's inliner needs the func dialect's inliner *extension* (which makes `func.call` inlinable — not registered here) **and** a `DialectInlinerInterface` for the StableHLO ops in the callee body (StableHLO registers none). With neither, the stock inliner silently no-ops and the call stayed on a runtime path whose `compile()` lowering hit issue 1.

## Fix

- **`MaybeBitcastNonFiniteFloat`**: materialize non-finite float constants via a bitcast of their integer bit-pattern (`view(array(uint_bits), float)`) — a *computed*, written value that compiles correctly.
- **Enable MLIR's stock inliner**: register `func::registerInlinerExtension` plus a permissive StableHLO/CHLO `DialectInlinerInterface`. The interface lives in the existing `-fno-rtti` pass translation unit (MLIR is built `-fno-rtti`, so an RTTI-compiled `DialectInterface` subclass fails to link — undefined typeinfo). With both registered, MLIR inlines the `@_where` helpers and the grads compile and fuse.
- **Safety net**: `has_uninlined_call` routes any call the inliner leaves in place to the eager path.
- Remove the now-passing `grad_xfail` marks for std and numpyro (Gamma, NegativeBinomial2, InverseGamma).

## Validation

- `grad(std)`/`var` now **compile** (no eager fallback) and match CPU; deterministic standalone repro fixed.
- **5/5 consecutive green full-suite soak runs** — `2204 passed, 0 failed` (was ~25% fire rate).
- `test_fusion.py` + `test_sysinfo.py` pass; all pre-commit hooks (clang-format, clang-tidy, pyright, build, full pytest) pass.

## Notes

A separate upstream MLX codegen bug (compiled `where` with a NaN **baked** constant → invalid Metal) was filed at tillahoffmann/mlx#2; it is related but not the cause of this issue, and this fix sidesteps it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)