### PR TITLE
feat(device): implement PJRT_Device_MemoryStats via MLX memory.h

### DIFF
--- a/src/pjrt_plugin/pjrt_device.cc
+++ b/src/pjrt_plugin/pjrt_device.cc
@@ -1,5 +1,7 @@
 // PJRT Device and DeviceDescription API implementation for Metal backend
 
+#include <mlx/mlx.h>
+
 #include "pjrt_plugin/logging.h"
 #include "pjrt_plugin/pjrt_types.h"
 
@@ -107,5 +109,34 @@ PJRT_Error* MPS_Device_DefaultMemory(PJRT_Device_DefaultMemory_Args* args) {
 }
 
 PJRT_Error* MPS_Device_MemoryStats(PJRT_Device_MemoryStats_Args* args) {
-    return MakeError("MemoryStats not implemented", PJRT_Error_Code_UNIMPLEMENTED);
+    // MLX tracks memory globally (unified-memory allocator), not per-device.
+    // We have a single Metal device, so the process-wide figures are exactly
+    // this device's stats.
+    //
+    // The caller does NOT zero-initialize the out fields, so every optional
+    // field's `_is_set` flag must be written explicitly: leave the ones MLX
+    // can't report set to false, otherwise JAX reads uninitialized garbage.
+    args->bytes_in_use = static_cast<int64_t>(mlx::core::get_active_memory());
+
+    args->peak_bytes_in_use = static_cast<int64_t>(mlx::core::get_peak_memory());
+    args->peak_bytes_in_use_is_set = true;
+
+    args->bytes_limit = static_cast<int64_t>(mlx::core::get_memory_limit());
+    args->bytes_limit_is_set = true;
+
+    // Memory held by the allocator = in-use plus the freed-but-retained cache.
+    args->pool_bytes = static_cast<int64_t>(mlx::core::get_active_memory()) +
+                       static_cast<int64_t>(mlx::core::get_cache_memory());
+    args->pool_bytes_is_set = true;
+
+    // Stats MLX does not expose.
+    args->num_allocs_is_set = false;
+    args->largest_alloc_size_is_set = false;
+    args->bytes_reserved_is_set = false;
+    args->peak_bytes_reserved_is_set = false;
+    args->bytes_reservable_limit_is_set = false;
+    args->largest_free_block_bytes_is_set = false;
+    args->peak_pool_bytes_is_set = false;
+
+    return nullptr;
 }

--- a/src/pjrt_plugin/pjrt_device.cc
+++ b/src/pjrt_plugin/pjrt_device.cc
@@ -116,7 +116,13 @@ PJRT_Error* MPS_Device_MemoryStats(PJRT_Device_MemoryStats_Args* args) {
     // The caller does NOT zero-initialize the out fields, so every optional
     // field's `_is_set` flag must be written explicitly: leave the ones MLX
     // can't report set to false, otherwise JAX reads uninitialized garbage.
-    args->bytes_in_use = static_cast<int64_t>(mlx::core::get_active_memory());
+    //
+    // Snapshot active memory once so the fields derived from it stay mutually
+    // consistent: querying separately could otherwise report
+    // `pool_bytes < bytes_in_use` if another thread (de)allocates in between.
+    const auto active = static_cast<int64_t>(mlx::core::get_active_memory());
+
+    args->bytes_in_use = active;
 
     args->peak_bytes_in_use = static_cast<int64_t>(mlx::core::get_peak_memory());
     args->peak_bytes_in_use_is_set = true;
@@ -125,8 +131,7 @@ PJRT_Error* MPS_Device_MemoryStats(PJRT_Device_MemoryStats_Args* args) {
     args->bytes_limit_is_set = true;
 
     // Memory held by the allocator = in-use plus the freed-but-retained cache.
-    args->pool_bytes = static_cast<int64_t>(mlx::core::get_active_memory()) +
-                       static_cast<int64_t>(mlx::core::get_cache_memory());
+    args->pool_bytes = active + static_cast<int64_t>(mlx::core::get_cache_memory());
     args->pool_bytes_is_set = true;
 
     // Stats MLX does not expose.

--- a/tests/test_memory_stats.py
+++ b/tests/test_memory_stats.py
@@ -1,0 +1,68 @@
+"""Tests for PJRT_Device_MemoryStats, backed by MLX's memory.h API.
+
+JAX surfaces the PJRT memory-stats call as ``device.memory_stats()``, which
+returns ``None`` when the backend reports ``UNIMPLEMENTED`` and a dict of
+stats otherwise.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+try:
+    MPS_DEVICE = jax.devices("mps")[0]
+except (RuntimeError, IndexError):
+    MPS_DEVICE = None
+
+pytestmark = pytest.mark.skipif(MPS_DEVICE is None, reason="MPS device required")
+
+
+def test_memory_stats_returns_dict():
+    assert MPS_DEVICE is not None
+    stats = MPS_DEVICE.memory_stats()
+    # A populated dict (not None) proves we no longer return UNIMPLEMENTED.
+    assert isinstance(stats, dict)
+    # bytes_in_use is the one field PJRT requires every backend to report.
+    assert "bytes_in_use" in stats
+    assert isinstance(stats["bytes_in_use"], int)
+    assert stats["bytes_in_use"] >= 0
+
+
+def test_memory_stats_optional_fields_present():
+    assert MPS_DEVICE is not None
+    stats = MPS_DEVICE.memory_stats()
+    # Fields we wire up from MLX memory.h. peak only grows, limit is positive.
+    assert stats["peak_bytes_in_use"] >= stats["bytes_in_use"]
+    assert stats["bytes_limit"] > 0
+    # pool_bytes (active + cached) is at least the in-use bytes.
+    assert stats["pool_bytes"] >= stats["bytes_in_use"]
+
+
+def test_memory_stats_reflects_allocation():
+    assert MPS_DEVICE is not None
+    # Peak memory never shrinks, so after an on-device computation that
+    # materializes a 4 MiB result the peak must be at least that large,
+    # regardless of caching/freeing behavior.
+    nbytes = 1024 * 1024 * 4  # 1024x1024 float32
+    x = jax.device_put(jnp.ones((1024, 1024), dtype=jnp.float32), MPS_DEVICE)
+    (x @ x).block_until_ready()
+    stats = MPS_DEVICE.memory_stats()
+    assert stats["peak_bytes_in_use"] >= nbytes
+
+
+def test_memory_stats_unreported_fields_are_sentinel():
+    assert MPS_DEVICE is not None
+    # Fields MLX cannot report must carry JAX's "not set" sentinel (-1),
+    # proving their `_is_set` flag is false rather than leaking the
+    # uninitialized struct memory the caller hands us.
+    stats = MPS_DEVICE.memory_stats()
+    for field in (
+        "num_allocs",
+        "largest_alloc_size",
+        "bytes_reserved",
+        "peak_bytes_reserved",
+        "largest_free_block_bytes",
+    ):
+        assert stats[field] == -1, f"{field} should be unset (-1), got {stats[field]}"


### PR DESCRIPTION
## Summary

`jax.devices("mps")[0].memory_stats()` previously returned `None`
(`PJRT_Device_MemoryStats` returned `UNIMPLEMENTED`). This wires it to MLX's
global memory accounting — since we expose a single Metal device, the
process-wide figures *are* this device's stats:

| PJRT field | MLX source (`mlx/memory.h`) |
| --- | --- |
| `bytes_in_use` | `get_active_memory()` |
| `peak_bytes_in_use` | `get_peak_memory()` |
| `bytes_limit` | `get_memory_limit()` |
| `pool_bytes` | `get_active_memory() + get_cache_memory()` (in-use + retained cache) |

Fields MLX cannot report (`num_allocs`, `largest_alloc_size`,
`bytes_reserved`, …) are left unset; JAX then surfaces its `-1` sentinel.

### Note on a subtle correctness point

The caller does **not** zero-initialize the args struct, so every optional
field's `_is_set` flag is written explicitly. Without this, fields we don't
populate read back uninitialized struct memory (observed e.g.
`num_allocs: 4349803360`, `bytes_reserved: 4340433352`).

## Test plan

New `tests/test_memory_stats.py` (device-level, mirrors `test_sysinfo.py`):

- `memory_stats()` returns a dict with a valid `bytes_in_use` (no longer `None`)
- `peak_bytes_in_use >= bytes_in_use`, `bytes_limit > 0`, `pool_bytes >= bytes_in_use`
- peak reflects a real on-device allocation (4 MiB matmul) — note `device_put`
  alone does not register in MLX's `get_active_memory()`; it's lazy until compute
- unreported fields carry the `-1` sentinel (guards against the garbage-leak bug)

All pre-commit hooks pass (clang-format, ruff, pyright, build, clang-tidy, pytest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)