### PR TITLE
feat(profiling): env-gated Metal GPU trace capture (JAX_MPS_GPU_CAPTURE)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,7 @@ uv run pytest -m benchmark --benchmark-only -n0
 - `JAX_MPS_NO_OPTIMIZE=1` disables the StableHLO simplification + MPS fusion passes. Useful for bisecting whether a regression comes from a fusion.
 - `JAX_MPS_DUMP_OPTIMIZED_IR=<dir>` writes each parsed+optimized module as `<dir>/module_<n>.mlir` (post-pass, so `@mps.*` custom_calls from fusion are visible). Used by `tests/test_fusion.py`; also handy for ad-hoc inspection.
 - `JAX_MPS_CACHE_LIMIT_BYTES=<n>` caps MLX's internal MTLBuffer cache (calls `mlx::core::set_cache_limit`). Unset by default — MLX picks ~1.5x the recommended working set. Set this when running many unrelated computations in one process (e.g. the upstream JAX suite via `scripts/run_jax_tests.py`, which sets 1 GiB) to prevent freed buffers from accumulating until the OS swaps them. Avoid for training/inference: a low cap forces per-iteration reallocation and regresses throughput on Max-class GPUs.
+- `JAX_MPS_GPU_CAPTURE=<path.gputrace>` captures a Metal GPU trace over a bounded window of `Execute` dispatches (default 1; set `JAX_MPS_GPU_CAPTURE_DISPATCHES=<n>` to widen) into a `.gputrace` document openable in Xcode/Instruments. Forces synchronous eval over the captured window so the GPU work is enclosed. Apple requires `MTL_CAPTURE_ENABLED=1` in the environment at process start; if it is missing the plugin prints a notice and disables capture rather than failing. Uses MLX's pure-C++ `mlx::core::metal::start_capture`/`stop_capture` (no Objective-C++).
 
 # Adding New Fusion Patterns
 

--- a/src/pjrt_plugin/mlx_executable.cc
+++ b/src/pjrt_plugin/mlx_executable.cc
@@ -486,8 +486,8 @@ struct GpuCaptureState {
         return active;
     }
 
-    // Call after the dispatch's outputs are materialized (or on the eval error
-    // path). Finalizes the trace once the window is full.
+    // Call after the dispatch's outputs are materialized. Finalizes the trace
+    // once the window is full.
     void EndDispatch() {
         if (!active) {
             return;
@@ -499,6 +499,22 @@ struct GpuCaptureState {
             fprintf(stderr, "[JAX_MPS_GPU_CAPTURE] wrote trace to %s\n", path.c_str());
         }
     }
+
+    // Call on the eval error path. Stops and flushes an in-progress capture
+    // unconditionally: EndDispatch only stops once the window is full, so a
+    // multi-dispatch window interrupted by an exception would otherwise leave
+    // MTLCaptureManager capturing indefinitely and never write the .gputrace.
+    void AbortCapture() {
+        if (!active) {
+            return;
+        }
+        mlx::core::metal::stop_capture();
+        active = false;
+        finished = true;
+        fprintf(stderr,
+                "[JAX_MPS_GPU_CAPTURE] eval failed mid-capture; wrote partial trace to %s\n",
+                path.c_str());
+    }
 };
 
 GpuCaptureState& GetGpuCaptureState() {
@@ -508,10 +524,12 @@ GpuCaptureState& GetGpuCaptureState() {
         if (path == nullptr || path[0] == '\0') {
             return s;  // disabled
         }
-        // Apple requires MTL_CAPTURE_ENABLED in the environment at process
-        // start; without it startCapture fails. Skip gracefully instead.
+        // Apple's Metal runtime only honors programmatic capture when
+        // MTL_CAPTURE_ENABLED=1 is set in the environment at process start;
+        // otherwise startCapture fails. Match that exact gate so we skip
+        // gracefully in the same cases Apple would reject.
         const char* cap = std::getenv("MTL_CAPTURE_ENABLED");
-        const bool cap_enabled = cap != nullptr && std::strcmp(cap, "0") != 0 && cap[0] != '\0';
+        const bool cap_enabled = cap != nullptr && std::strcmp(cap, "1") == 0;
         if (!cap_enabled) {
             fprintf(stderr,
                     "[JAX_MPS_GPU_CAPTURE] ignoring: Metal GPU capture requires "
@@ -918,7 +936,7 @@ MlxExecuteResult MlxExecutable::Execute(const std::vector<MlxBuffer*>& inputs) {
         } catch (const std::exception& e) {
             MPS_LOG_ERROR("MLX evaluation failed: %s\n", e.what());
             result.error_message = std::string("eval: ") + e.what();
-            capture.EndDispatch();
+            capture.AbortCapture();
             return result;
         }
         capture.EndDispatch();

--- a/src/pjrt_plugin/mlx_executable.cc
+++ b/src/pjrt_plugin/mlx_executable.cc
@@ -2,6 +2,7 @@
 
 #include "pjrt_plugin/mlx_executable.h"
 
+#include <mlx/backend/metal/metal.h>
 #include <mlx/compile.h>
 #include <mlx/memory.h>
 #include <mlx/mlx.h>
@@ -439,6 +440,98 @@ ProfilingState& GetProfilingState() {
     return state;
 }
 
+// GPU trace capture, gated by JAX_MPS_GPU_CAPTURE=<path-to-.gputrace>.
+//
+// Captures a bounded window of Execute() dispatches into a single Metal trace
+// document (openable in Xcode/Instruments) via MLX's pure-C++ wrappers around
+// MTLCaptureManager. The window spans JAX_MPS_GPU_CAPTURE_DISPATCHES dispatches
+// (default 1): capture starts before the first and stops after the last.
+//
+// Apple gates programmatic capture behind MTL_CAPTURE_ENABLED=1, which must be
+// present in the environment at process start. We check it ourselves and
+// disable capture with a clear message, rather than letting MLX's
+// start_capture() throw mid-execution. (We still guard start_capture with a
+// try/catch for the residual failure modes, e.g. an unwritable destination.)
+//
+// State is process-global and only meaningful for single-threaded debugging;
+// concurrent Execute() calls would race the dispatch counter, which is
+// acceptable for an opt-in capture tool.
+struct GpuCaptureState {
+    bool enabled = false;
+    bool active = false;
+    bool finished = false;
+    std::string path;
+    int total_dispatches = 1;
+    int seen = 0;
+
+    // Call before eval. Returns true when capture is active for this dispatch,
+    // in which case the caller MUST use a synchronous eval so the GPU work is
+    // enclosed by the capture window (async_eval returns before completion).
+    bool BeginDispatch() {
+        if (!enabled || finished) {
+            return false;
+        }
+        if (seen == 0) {
+            try {
+                mlx::core::metal::start_capture(path);
+            } catch (const std::exception& e) {
+                fprintf(stderr, "[JAX_MPS_GPU_CAPTURE] failed to start capture: %s\n", e.what());
+                enabled = false;
+                return false;
+            }
+            active = true;
+            fprintf(stderr, "[JAX_MPS_GPU_CAPTURE] capturing %d dispatch(es) to %s\n",
+                    total_dispatches, path.c_str());
+        }
+        return active;
+    }
+
+    // Call after the dispatch's outputs are materialized (or on the eval error
+    // path). Finalizes the trace once the window is full.
+    void EndDispatch() {
+        if (!active) {
+            return;
+        }
+        if (++seen >= total_dispatches) {
+            mlx::core::metal::stop_capture();
+            active = false;
+            finished = true;
+            fprintf(stderr, "[JAX_MPS_GPU_CAPTURE] wrote trace to %s\n", path.c_str());
+        }
+    }
+};
+
+GpuCaptureState& GetGpuCaptureState() {
+    static GpuCaptureState state = [] {
+        GpuCaptureState s;
+        const char* path = std::getenv("JAX_MPS_GPU_CAPTURE");
+        if (path == nullptr || path[0] == '\0') {
+            return s;  // disabled
+        }
+        // Apple requires MTL_CAPTURE_ENABLED in the environment at process
+        // start; without it startCapture fails. Skip gracefully instead.
+        const char* cap = std::getenv("MTL_CAPTURE_ENABLED");
+        const bool cap_enabled = cap != nullptr && std::strcmp(cap, "0") != 0 && cap[0] != '\0';
+        if (!cap_enabled) {
+            fprintf(stderr,
+                    "[JAX_MPS_GPU_CAPTURE] ignoring: Metal GPU capture requires "
+                    "MTL_CAPTURE_ENABLED=1 in the environment at process start.\n");
+            return s;
+        }
+        s.path = path;
+        s.enabled = true;
+        if (const char* n = std::getenv("JAX_MPS_GPU_CAPTURE_DISPATCHES")) {
+            char* end = nullptr;
+            const long parsed = std::strtol(n, &end, 10);
+            if (end != n && *end == '\0' && parsed > 0) {
+                s.total_dispatches = static_cast<int>(parsed);
+            }
+        }
+        return s;
+    }();
+    return state;
+}
+
 // --- Op dispatch table ---
 
 const std::unordered_map<std::string, OpHandler>& GetOpHandlers() {
@@ -797,8 +890,13 @@ MlxExecuteResult MlxExecutable::Execute(const std::vector<MlxBuffer*>& inputs) {
         eval_start = Clock::now();
     }
     if (!outputs.empty()) {
+        // While a GPU trace capture window is open we force a synchronous eval:
+        // async_eval returns before the GPU work completes, which would leave
+        // the dispatched command buffers outside the capture window.
+        auto& capture = GetGpuCaptureState();
+        const bool capturing = capture.BeginDispatch();
         try {
-            if (IsAsyncDispatchEnabled()) {
+            if (IsAsyncDispatchEnabled() && !capturing) {
                 // Resolve any control-flow primitives (while/case) synchronously
                 // first: their internal re-entrant eval() deadlocks under an
                 // async_eval outer pass (it waits cross-stream on a per-stream
@@ -820,8 +918,10 @@ MlxExecuteResult MlxExecutable::Execute(const std::vector<MlxBuffer*>& inputs) {
         } catch (const std::exception& e) {
             MPS_LOG_ERROR("MLX evaluation failed: %s\n", e.what());
             result.error_message = std::string("eval: ") + e.what();
+            capture.EndDispatch();
             return result;
         }
+        capture.EndDispatch();
     }
     if (profiling) {
         eval_end = Clock::now();

--- a/tests/test_gpu_capture.py
+++ b/tests/test_gpu_capture.py
@@ -1,0 +1,77 @@
+"""Tests for env-gated Metal GPU trace capture.
+
+``JAX_MPS_GPU_CAPTURE=<path>`` makes the plugin wrap a bounded window of
+``Execute`` dispatches in ``mlx::core::metal::start_capture``/``stop_capture``,
+writing a ``.gputrace`` document openable in Xcode/Instruments.
+
+Apple gates programmatic capture behind ``MTL_CAPTURE_ENABLED=1`` in the
+environment at process start; the plugin checks for it and disables capture
+with a clear message rather than crashing when it is missing. Both behaviours
+are exercised here via subprocesses (the env vars must be set before the
+process — and the Metal device — initialize).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import jax
+import pytest
+
+try:
+    MPS_DEVICE = jax.devices("mps")[0]
+except (RuntimeError, IndexError):
+    MPS_DEVICE = None
+
+pytestmark = pytest.mark.skipif(MPS_DEVICE is None, reason="MPS device required")
+
+# A minimal on-device computation: force the work onto MPS and block so the
+# matmul actually dispatches (and so the captured command buffer is non-empty).
+_WORKLOAD = (
+    "import jax, jax.numpy as jnp;"
+    "d = jax.devices('mps')[0];"
+    "x = jax.device_put(jnp.ones((128, 128), jnp.float32), d);"
+    "(x @ x).block_until_ready()"
+)
+
+
+def _run_workload(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-c", _WORKLOAD],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+
+
+def test_gpu_capture_writes_trace(tmp_path):
+    trace = tmp_path / "capture.gputrace"
+    env = {
+        **os.environ,
+        "MTL_CAPTURE_ENABLED": "1",
+        "JAX_MPS_GPU_CAPTURE": str(trace),
+    }
+    result = _run_workload(env)
+    assert result.returncode == 0, result.stderr
+    assert trace.exists(), f"trace not written; stderr:\n{result.stderr}"
+    # A .gputrace is a bundle (directory) on macOS; require it to hold content.
+    if trace.is_dir():
+        assert any(trace.rglob("*")), "trace bundle is empty"
+    else:
+        assert trace.stat().st_size > 0, "trace file is empty"
+
+
+def test_gpu_capture_without_mtl_enabled_is_graceful(tmp_path):
+    trace = tmp_path / "capture.gputrace"
+    env = {**os.environ, "JAX_MPS_GPU_CAPTURE": str(trace)}
+    env.pop("MTL_CAPTURE_ENABLED", None)
+    result = _run_workload(env)
+    # Missing MTL_CAPTURE_ENABLED must NOT fail the run: capture is disabled.
+    assert result.returncode == 0, result.stderr
+    assert not trace.exists(), "trace should not be written without MTL_CAPTURE_ENABLED"
+    assert "MTL_CAPTURE_ENABLED" in result.stderr, (
+        f"expected a message naming MTL_CAPTURE_ENABLED; stderr:\n{result.stderr}"
+    )


### PR DESCRIPTION
## Summary

Adds an opt-in path to capture a Metal GPU trace over a bounded window of `Execute()` dispatches into a `.gputrace` document (openable in Xcode/Instruments).

- `JAX_MPS_GPU_CAPTURE=<path.gputrace>` enables capture; the value is the destination.
- `JAX_MPS_GPU_CAPTURE_DISPATCHES=<n>` sets the window length (default `1`): capture starts before the first dispatch and stops after the n-th, then flushes the document.
- Uses MLX's pure-C++ wrappers (`mlx::core::metal::start_capture`/`stop_capture`), so **no Objective-C++/`.mm` is reintroduced** — MLX hides MTLCaptureManager behind metal-cpp.
- While the window is open we force a **synchronous eval** even under `JAX_MPS_ASYNC_DISPATCH`, so the GPU work is enclosed by the capture (async_eval returns before completion).
- Apple gates programmatic capture behind `MTL_CAPTURE_ENABLED=1` at process start. We check it ourselves and disable capture with a clear stderr notice rather than letting `start_capture` throw mid-execution.

## Testing

`tests/test_gpu_capture.py` drives both paths via subprocesses (the env vars must precede process/Metal init):
- **Happy path**: with `MTL_CAPTURE_ENABLED=1`, asserts a non-empty `.gputrace` bundle is written.
- **Graceful path**: with the gate unset, asserts the run still succeeds (no trace, clear notice naming `MTL_CAPTURE_ENABLED`).

Verified end-to-end on the ResNet example: capture fires, training is unaffected, and the resulting bundle is a valid Metal trace.

## Notes

The capture produces a *frame capture* (structure + command stream), not a *profiled* capture (per-kernel timings). For timing, `xctrace record --template 'Metal System Trace'` is the pure-CLI path. See follow-up issue on async-dispatch perf in ResNet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)