### PR TITLE
fix(mlx): don't abort the process when an op throws on a stream worker thread

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,4 +52,8 @@ repos:
         entry: bash -c 'CI=true uv run pytest -q'
         language: system
         pass_filenames: false
-        exclude: ^\.github/workflows/
+        # Only run the (slow) suite when code or the environment that affects
+        # it changes; skip it for docs-only commits such as README badge
+        # updates. Covers source, tests, project config, the pyright config,
+        # and the dependency lockfile.
+        files: ^(src/|tests/|pyproject\.toml|pyrightconfig\.json|uv\.lock)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jax-mps
 
-[![GitHub Action Badge](https://github.com/tillahoffmann/jax-mps/actions/workflows/build.yml/badge.svg)](https://github.com/tillahoffmann/jax-mps/actions/workflows/build.yml) [![PyPI](https://img.shields.io/pypi/v/jax-mps)](https://pypi.org/project/jax-mps/) ![JAX tests](https://img.shields.io/badge/JAX_tests-92.7%25_passing-yellow)[^1]
+[![GitHub Action Badge](https://github.com/tillahoffmann/jax-mps/actions/workflows/build.yml/badge.svg)](https://github.com/tillahoffmann/jax-mps/actions/workflows/build.yml) [![PyPI](https://img.shields.io/pypi/v/jax-mps)](https://pypi.org/project/jax-mps/) ![JAX tests](https://img.shields.io/badge/JAX_tests-93.1%25_passing-yellow)[^1]
 
 A JAX backend for Apple Silicon using [MLX](https://github.com/ml-explore/mlx), enabling GPU-accelerated JAX computations on Mac.
 

--- a/scripts/run_jax_tests.py
+++ b/scripts/run_jax_tests.py
@@ -166,12 +166,32 @@ def main():
     )
     args = parser.parse_args()
 
+    # Line-buffer our own output so it stays in chronological order relative to
+    # the pytest child's stream. Without this, parent print()s are block-
+    # buffered when redirected to a file and only flush at exit, landing AFTER
+    # all of pytest's output — so a native crash (e.g. an MLX op throwing on a
+    # stream thread -> abort) leaves a log whose tail does not reflect what was
+    # actually running.
+    for stream in (sys.stdout, sys.stderr):
+        # reconfigure() exists on TextIOWrapper (the usual stdout/stderr) but
+        # not on every TextIO; getattr keeps the type checker happy and is a
+        # no-op if the stream was replaced with something that lacks it.
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is not None:
+            reconfigure(line_buffering=True)
+
     project_root = Path(__file__).resolve().parent.parent
     results_dir = Path(args.results_dir)
     results_dir.mkdir(parents=True, exist_ok=True)
     xml_dir = results_dir / "xml"
     xml_dir.mkdir(parents=True, exist_ok=True)
     clone_dir = Path(args.clone_dir)
+
+    # Always track the currently-running test. If pytest dies without writing
+    # JUnit XML (native crash/abort), this file still holds the nodeid of the
+    # test that was running, so we can name the culprit immediately instead of
+    # bisecting. Defaults under results_dir; overridable via --current-test-file.
+    current_test_file = args.current_test_file or str(results_dir / "current_test.txt")
 
     version = get_jax_version()
     print(f"JAX version: {version}")
@@ -209,19 +229,23 @@ def main():
         "-q",
         f"--timeout={args.timeout}",
         "--continue-on-collection-errors",
+        # Track the in-progress test (see current_test_file above) so a crash
+        # that prevents JUnit XML from being written can still be attributed.
+        "-p",
+        "_pytest_memory_plugin",
+        f"--current-test-file={current_test_file}",
     ]
-    if args.memory_csv or args.current_test_file:
-        cmd += ["-p", "_pytest_memory_plugin"]
     if args.memory_csv:
         cmd += [f"--memory-csv={args.memory_csv}"]
-    if args.current_test_file:
-        cmd += [f"--current-test-file={args.current_test_file}"]
     # Cap MLX's buffer cache for the test-suite scenario: thousands of
     # unrelated computations in one process otherwise leave freed MTLBuffers
     # resident until they swap (see #134, #139). Real workloads keep MLX's
     # tuned default; only the test runner sets this.
     env = {
         **os.environ,
+        # Unbuffered child stdout/stderr so pytest's progress (and any crash
+        # output) reaches the log live rather than in deferred blocks.
+        "PYTHONUNBUFFERED": "1",
         "JAX_PLATFORMS": "mps",
         "JAX_MPS_CACHE_LIMIT_BYTES": os.environ.get(
             "JAX_MPS_CACHE_LIMIT_BYTES", str(1 << 30)
@@ -233,12 +257,25 @@ def main():
     env["PYTHONPATH"] = (scripts_dir + os.pathsep + env.get("PYTHONPATH", "")).rstrip(
         os.pathsep
     )
-    print(f"\nRunning: pytest {tests_dir} ...\n")
+    print(f"\nRunning: pytest {tests_dir} ...")
+    print(f"Current-test tracker: {current_test_file}\n")
     subprocess.run(cmd, cwd=project_root, env=env)
 
     # Parse results
     if not xml_path.exists():
         print("\nERROR: No JUnit XML produced — pytest may have crashed.")
+        try:
+            last = Path(current_test_file).read_text().strip()
+        except OSError:
+            last = ""
+        if last:
+            print(f"Last test running when pytest died: {last}")
+        else:
+            print(
+                "No in-progress test was recorded — the crash happened during "
+                "collection/teardown or before the first test started "
+                f"(tracker: {current_test_file})."
+            )
         sys.exit(1)
 
     totals = parse_junit_xml(xml_path)

--- a/tests/test_eigh_failure_no_abort.py
+++ b/tests/test_eigh_failure_no_abort.py
@@ -1,0 +1,85 @@
+"""A failing MLX op must raise a catchable error, not abort the process.
+
+MLX evaluates an op's ``eval_cpu``/``eval_gpu`` work in a lambda dispatched onto
+a scheduler *stream worker thread*. Stock MLX runs that lambda with no
+exception handling (``StreamThread::thread_fn`` calls ``task()`` bare), so when
+an op throws on the worker thread the exception unwinds off the top of the
+thread -> ``std::terminate`` -> ``abort()``, killing the whole process. Our
+``Execute`` try/catch only guards the dispatch thread and cannot catch this.
+
+The trigger here is ``eigh`` on a non-convergent input: LAPACK ``syevd`` returns
+``info != 0`` and ``eigh_impl`` throws ``std::runtime_error`` inside its
+dispatched lambda. LOBPCG reaches it via its Rayleigh-Ritz step on an
+ill-conditioned (cond 1e5) projection -- this is the exact computation that
+aborted the upstream JAX suite at ``lobpcg_test.py::...geom_cond_100k``.
+
+A vendored MLX patch (``third_party/mlx/patches/10-...``) catches the worker
+exception and re-throws it at the next synchronization point, turning the abort
+into an ordinary Python exception. This test pins that behaviour. It runs in a
+subprocess because, pre-fix, the failure is a process-level ``abort()`` that no
+in-process ``try/except`` can catch.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import jax
+import pytest
+
+try:
+    MPS_DEVICE = jax.devices("mps")[0]
+except (RuntimeError, IndexError):
+    MPS_DEVICE = None
+
+pytestmark = pytest.mark.skipif(MPS_DEVICE is None, reason="MPS device required")
+
+# Drive MLX eigh to a non-convergent input via LOBPCG on a diagonal operator
+# with a geometric spectrum spanning 1..1e5 (condition number 1e5). The
+# Rayleigh-Ritz eigh on the float32 projection fails (syevd info != 0). The
+# computation is wrapped in try/except: post-fix the failure is a catchable
+# Python exception, so the process exits 0 having printed a NOABORT sentinel;
+# pre-fix the process aborts (SIGABRT) before reaching either print.
+_WORKLOAD = (
+    "import os; os.environ.setdefault('JAX_PLATFORMS', 'mps');"
+    "import numpy as np, jax, jax.numpy as jnp;"
+    "from jax.experimental.sparse import linalg as splinalg;"
+    "n = 100;"
+    "diagonal = np.logspace(0, 5, n).astype(np.float32);"
+    "X = jax.random.normal(jax.random.PRNGKey(0), (n, 10), dtype=jnp.float32);"
+    "f = lambda Z: diagonal[:, None] * Z;"
+    "\ntry:\n"
+    "    theta, _, _ = splinalg.lobpcg_standard(f, X, m=20);\n"
+    "    jax.block_until_ready(theta);\n"
+    "    print('NOABORT:COMPLETED')\n"
+    "except Exception as e:\n"
+    "    print('NOABORT:RAISED', type(e).__name__)\n"
+)
+
+
+def test_failing_eigh_raises_instead_of_aborting():
+    result = subprocess.run(
+        [sys.executable, "-c", _WORKLOAD],
+        env={**os.environ, "JAX_PLATFORMS": "mps"},
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    # The op failure must surface as a normal Python exception (or the
+    # computation completes); either way the process exits cleanly rather than
+    # aborting. SIGABRT shows up as returncode -6.
+    assert result.returncode == 0, (
+        f"process did not exit cleanly (returncode={result.returncode}); a "
+        f"failing MLX op should raise, not abort.\nstdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+    assert "NOABORT:" in result.stdout, (
+        f"sentinel missing — the worker-thread exception was not caught.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "terminating due to uncaught exception" not in result.stderr, (
+        f"MLX still terminated on an uncaught worker-thread exception.\n"
+        f"stderr:\n{result.stderr}"
+    )

--- a/tests/test_eigh_failure_no_abort.py
+++ b/tests/test_eigh_failure_no_abort.py
@@ -40,8 +40,8 @@ pytestmark = pytest.mark.skipif(MPS_DEVICE is None, reason="MPS device required"
 # with a geometric spectrum spanning 1..1e5 (condition number 1e5). The
 # Rayleigh-Ritz eigh on the float32 projection fails (syevd info != 0). The
 # computation is wrapped in try/except: post-fix the failure is a catchable
-# Python exception, so the process exits 0 having printed a NOABORT sentinel;
-# pre-fix the process aborts (SIGABRT) before reaching either print.
+# Python exception, so the process exits 0 having printed NOABORT:RAISED with
+# the MLX error message; pre-fix the process aborts (SIGABRT) before any print.
 _WORKLOAD = (
     "import os; os.environ.setdefault('JAX_PLATFORMS', 'mps');"
     "import numpy as np, jax, jax.numpy as jnp;"
@@ -55,7 +55,7 @@ _WORKLOAD = (
     "    jax.block_until_ready(theta);\n"
     "    print('NOABORT:COMPLETED')\n"
     "except Exception as e:\n"
-    "    print('NOABORT:RAISED', type(e).__name__)\n"
+    "    print('NOABORT:RAISED', repr(str(e)))\n"
 )
 
 
@@ -67,16 +67,26 @@ def test_failing_eigh_raises_instead_of_aborting():
         text=True,
         timeout=300,
     )
-    # The op failure must surface as a normal Python exception (or the
-    # computation completes); either way the process exits cleanly rather than
-    # aborting. SIGABRT shows up as returncode -6.
+    # The op failure must surface as a normal Python exception, so the process
+    # exits cleanly (returncode 0) rather than aborting. SIGABRT shows up as
+    # returncode -6.
     assert result.returncode == 0, (
         f"process did not exit cleanly (returncode={result.returncode}); a "
         f"failing MLX op should raise, not abort.\nstdout:\n{result.stdout}\n"
         f"stderr:\n{result.stderr}"
     )
-    assert "NOABORT:" in result.stdout, (
-        f"sentinel missing — the worker-thread exception was not caught.\n"
+    # Require the raised path specifically: a silent NOABORT:COMPLETED would
+    # mean the failing eigh path stopped triggering and the test no longer
+    # exercises the regression.
+    assert "NOABORT:RAISED" in result.stdout, (
+        f"expected the failure to surface as a catchable exception, but it did "
+        f"not (no NOABORT:RAISED).\nstdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+    # And that it is the worker-thread eigh failure that surfaced, not some
+    # unrelated error.
+    assert "Eigenvalue decomposition failed" in result.stdout, (
+        f"raised exception did not carry the MLX eigh error message.\n"
         f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
     )
     assert "terminating due to uncaught exception" not in result.stderr, (

--- a/third_party/mlx/patches/10-scheduler-catch-task-exceptions.patch
+++ b/third_party/mlx/patches/10-scheduler-catch-task-exceptions.patch
@@ -1,0 +1,153 @@
+diff --git a/mlx/array.cpp b/mlx/array.cpp
+index e694ccf..60b4a91 100644
+--- a/mlx/array.cpp
++++ b/mlx/array.cpp
+@@ -5,6 +5,7 @@
+ #include "mlx/array.h"
+ #include "mlx/ops.h"
+ #include "mlx/primitives.h"
++#include "mlx/scheduler.h"
+ #include "mlx/transforms.h"
+ #include "mlx/transforms_impl.h"
+ 
+@@ -149,6 +150,11 @@ void array::wait() {
+     }
+     set_status(Status::available);
+   }
++  // Surface any exception thrown by an op's eval lambda on a stream worker
++  // thread. The throwing task was caught in StreamThread::thread_fn (rather
++  // than aborting the process); rethrow it here, at the synchronization
++  // barrier, so the caller observes an ordinary exception.
++  scheduler::rethrow_pending_exception();
+ }
+ 
+ void array::eval() {
+diff --git a/mlx/backend/cpu/encoder.h b/mlx/backend/cpu/encoder.h
+index 9a2c35a..ef24879 100644
+--- a/mlx/backend/cpu/encoder.h
++++ b/mlx/backend/cpu/encoder.h
+@@ -47,7 +47,14 @@ struct MLX_API CommandEncoder {
+     if (num_ops_ == 0) {
+       scheduler::notify_new_task(stream_);
+       auto task_wrap = [s = stream_, task = std::move(task)]() mutable {
+-        task();
++        // Always balance the notify_new_task above, even if the task throws,
++        // so n_active_tasks_ cannot leak and stall a later wait_for_one().
++        try {
++          task();
++        } catch (...) {
++          scheduler::notify_task_completion(s);
++          throw;
++        }
+         scheduler::notify_task_completion(s);
+       };
+       scheduler::enqueue(stream_, std::move(task_wrap));
+diff --git a/mlx/scheduler.cpp b/mlx/scheduler.cpp
+index e0b467a..52e8849 100644
+--- a/mlx/scheduler.cpp
++++ b/mlx/scheduler.cpp
+@@ -1,6 +1,11 @@
+ // Copyright © 2023-2026 Apple Inc.
+ 
+ #include "mlx/scheduler.h"
++
++#include <atomic>
++#include <exception>
++#include <mutex>
++
+ #include "mlx/backend/cpu/eval.h"
+ #include "mlx/backend/gpu/eval.h"
+ 
+@@ -68,5 +73,51 @@ Scheduler& scheduler() {
+   return *scheduler;
+ }
+ 
++namespace {
++
++std::mutex& pending_exception_mutex() {
++  static std::mutex m;
++  return m;
++}
++
++std::exception_ptr& pending_exception() {
++  static std::exception_ptr e;
++  return e;
++}
++
++// Fast-path flag so the common (no-error) synchronization path avoids taking
++// the mutex on every wait.
++std::atomic<bool>& has_pending_exception() {
++  static std::atomic<bool> flag{false};
++  return flag;
++}
++
++} // namespace
++
++void set_pending_exception(std::exception_ptr e) {
++  std::lock_guard<std::mutex> lk(pending_exception_mutex());
++  if (!pending_exception()) {
++    // Keep the first exception; later failures on a poisoned stream are noise.
++    pending_exception() = std::move(e);
++    has_pending_exception().store(true, std::memory_order_release);
++  }
++}
++
++void rethrow_pending_exception() {
++  if (!has_pending_exception().load(std::memory_order_acquire)) {
++    return;
++  }
++  std::exception_ptr e;
++  {
++    std::lock_guard<std::mutex> lk(pending_exception_mutex());
++    e = pending_exception();
++    pending_exception() = nullptr;
++    has_pending_exception().store(false, std::memory_order_release);
++  }
++  if (e) {
++    std::rethrow_exception(e);
++  }
++}
++
+ } // namespace scheduler
+ } // namespace mlx::core
+diff --git a/mlx/scheduler.h b/mlx/scheduler.h
+index c84ab62..2f505a8 100644
+--- a/mlx/scheduler.h
++++ b/mlx/scheduler.h
+@@ -3,6 +3,7 @@
+ #pragma once
+ 
+ #include <atomic>
++#include <exception>
+ #include <future>
+ #include <queue>
+ #include <shared_mutex>
+@@ -16,6 +17,13 @@
+ 
+ namespace mlx::core::scheduler {
+ 
++// A task running on a stream worker thread (an op's eval_cpu/eval_gpu lambda)
++// may throw. Capturing the first such exception lets it be re-thrown at the
++// next synchronization point (see array::wait) instead of escaping the worker
++// thread, which would call std::terminate and abort the whole process.
++MLX_API void set_pending_exception(std::exception_ptr e);
++MLX_API void rethrow_pending_exception();
++
+ struct StreamThread {
+   std::mutex mtx;
+   std::queue<std::function<void()>> q;
+@@ -47,7 +55,13 @@ struct StreamThread {
+         q.pop();
+       }
+ 
+-      task();
++      // Never let an exception escape the worker thread: that would terminate
++      // the process. Capture it and re-throw at the next synchronization point.
++      try {
++        task();
++      } catch (...) {
++        set_pending_exception(std::current_exception());
++      }
+     }
+   }
+ 

--- a/third_party/mlx/patches/10-scheduler-catch-task-exceptions.patch
+++ b/third_party/mlx/patches/10-scheduler-catch-task-exceptions.patch
@@ -1,5 +1,5 @@
 diff --git a/mlx/array.cpp b/mlx/array.cpp
-index e694ccf..60b4a91 100644
+index e694ccf..ecf6246 100644
 --- a/mlx/array.cpp
 +++ b/mlx/array.cpp
 @@ -5,6 +5,7 @@
@@ -10,18 +10,20 @@ index e694ccf..60b4a91 100644
  #include "mlx/transforms.h"
  #include "mlx/transforms_impl.h"
  
-@@ -149,6 +150,11 @@ void array::wait() {
+@@ -147,6 +148,13 @@ void array::wait() {
+       event().wait();
+       detach_event();
      }
++    // Surface any exception thrown by an op's eval lambda on a stream worker
++    // thread. The throwing task was caught in StreamThread::thread_fn (rather
++    // than aborting the process); rethrow it here, at the synchronization
++    // barrier, so the caller observes an ordinary exception. Do this *before*
++    // marking the array available, mirroring how a poisoned GPU event makes
++    // event().wait() above throw: a failed array must not be left ready.
++    scheduler::rethrow_pending_exception();
      set_status(Status::available);
    }
-+  // Surface any exception thrown by an op's eval lambda on a stream worker
-+  // thread. The throwing task was caught in StreamThread::thread_fn (rather
-+  // than aborting the process); rethrow it here, at the synchronization
-+  // barrier, so the caller observes an ordinary exception.
-+  scheduler::rethrow_pending_exception();
  }
- 
- void array::eval() {
 diff --git a/mlx/backend/cpu/encoder.h b/mlx/backend/cpu/encoder.h
 index 9a2c35a..ef24879 100644
 --- a/mlx/backend/cpu/encoder.h


### PR DESCRIPTION
## Problem

The upstream JAX test suite (the pass-rate badge run) **aborts mid-run with `SIGABRT`**, producing no JUnit XML — so no result and, until now, no clue which test caused it. The trigger is `eigh` on a non-convergent input: LAPACK `syevd` returns `info != 0` and `eigh_impl` throws `std::runtime_error("[Eigh::eval_cpu] Eigenvalue decomposition failed ...")`.

## Root cause

MLX runs an op's `eval_cpu`/`eval_gpu` work in a lambda dispatched onto a scheduler **stream worker thread**. `StreamThread::thread_fn` ran that lambda bare (`task();`), so the exception unwound off the top of the worker thread → `std::terminate` → `abort()`, killing the whole process. Our `Execute` try/catch only guards the dispatch thread and cannot catch this.

This is a general fragility (any throwing op — cholesky on non-PD, etc. — does the same); `eigh` is just the trigger the suite hits. Upstream MLX [#3523](https://github.com/ml-explore/mlx/pull/3523) ("Catch error in CommandBuffer and poison the events", = our pinned commit `a025496`) added this protection for the **GPU** CommandBuffer/Event path but left the **CPU** worker thread unguarded.

## Fix (`third_party/mlx/patches/10-scheduler-catch-task-exceptions.patch`)

- `scheduler.h` `thread_fn` — wrap `task()` in try/catch; stash the first exception into a process-global `exception_ptr` (atomic fast-path).
- `array.cpp` `array::wait()` — rethrow the stashed exception at the universal main-thread synchronization barrier, so the caller observes an ordinary (catchable) exception.
- `backend/cpu/encoder.h` — make the completion-notify task wrap exception-safe so `n_active_tasks_` can't leak (and stall a later `wait_for_one()`) on a throw.

### Why rethrow-at-`wait()` rather than the GPU-style event poison

The GPU mechanism propagates errors through `EventImpl::set_error`/`check_error` + encoder poisoning. Mirroring that on CPU **doesn't surface in jax-mps**: the default device is GPU, so `eigh` runs on a *CPU stream* while the eval synchronizer event is on the *GPU stream*, and the intra-eval CPU→GPU hand-off in synchronous `eval()` uses an error-less **`Fence`** (per-array Events exist only on the async path). So a literal event-poison would never reach the surfacing event. Rethrowing at `array::wait()` sidesteps this because it's the universal main-thread barrier regardless of stream. (A fully GPU-idiomatic CPU fix would also need to give `Fence` error carriage — more than #3523 did — and is better done upstream.)

## Tests

- `tests/test_eigh_failure_no_abort.py` — subprocess regression test. Pre-fix the process aborts (`SIGABRT`, returncode -6); post-fix the failure surfaces as a catchable `jax.errors.JaxRuntimeError` and the process exits cleanly.
- Verified the full project `pytest` suite passes (pre-commit hook), normal `eigh` still works, and a 267-test ops/control-flow smoke is unaffected.

## Diagnostics (separate commit)

`scripts/run_jax_tests.py` now always tracks the in-flight test (`--current-test-file`) and line-buffers parent + child output (`PYTHONUNBUFFERED=1`), and on the no-XML crash branch prints `Last test running when pytest died: <nodeid>`. This is what pinned the culprit (`lobpcg_test::testCallableMatricesF32geom_cond_100k` — an *indirect* eigh user via its Rayleigh-Ritz step) on the first re-run.

## Follow-up

The pass-rate badge in `README.md` will be updated in a follow-up commit once the now-completing suite run finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)