### PR TITLE
test(jax-suite): exclude documentation_coverage_test (not a backend test)

### DIFF
--- a/scripts/run_jax_tests.py
+++ b/scripts/run_jax_tests.py
@@ -38,6 +38,9 @@ EXCLUDED_FILES = {
     #          modules absent from the jax wheel).
     "multiprocess",  # Multi-host tests require multiple processes/devices;
     #          MPS presents a single device on one host.
+    "documentation_coverage_test.py",  # Reads JAX's docs/ RST tree (e.g.
+    #          docs/jax.numpy.rst), which the tests-only runner does not fetch;
+    #          they validate JAX's documentation coverage, not the MPS backend.
 }
 
 # Test-only modules that live in the JAX source tree but are NOT shipped in the


### PR DESCRIPTION
## Summary

Excludes `documentation_coverage_test.py` from the upstream JAX test suite runner (`scripts/run_jax_tests.py`).

These tests read JAX's own `docs/` RST tree (e.g. `docs/jax.numpy.rst`) to verify documentation completeness. The runner fetches **only** the `tests/` tree from the pinned source tarball and never downloads `docs/`, so all ~73 of these tests fail with `FileNotFoundError: .../docs/jax.numpy.rst`.

They validate JAX's *documentation coverage*, not the MPS backend, so they are out of scope for the backend pass-rate badge — exactly the kind of non-backend suite already excluded (`mosaic`, `multiprocess`, `pallas`, etc.).

## Notes

- The README pass-rate badge is intentionally **not** updated in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)