### PR TITLE
feat(reduce_window): support base dilation

### DIFF
--- a/src/pjrt_plugin/ops/reduction.cc
+++ b/src/pjrt_plugin/ops/reduction.cc
@@ -306,15 +306,46 @@ bool HandleReduceWindow(mlir::Operation* op, ValueMap& values,
     }
 
     // ---------- Tier 2: Pooling pattern ----------
-    if (!allBaseDilOne) {
-        MPS_LOG_ERROR("stablehlo.reduce_window: base dilations not supported\n");
-        return false;
-    }
-
     if (reduceType != ReduceType::Max && reduceType != ReduceType::Sum &&
         reduceType != ReduceType::Min && reduceType != ReduceType::Prod) {
         MPS_LOG_ERROR("stablehlo.reduce_window: pooling supports max/sum/min/prod only\n");
         return false;
+    }
+
+    // Base dilation: StableHLO dilates the *input* by inserting (base_dil - 1)
+    // holes between elements along each axis BEFORE padding and windowing, with
+    // the holes filled by the init value. init is the reduction identity
+    // (0/-inf/+inf/1 for sum/max/min/prod), so the holes never affect the
+    // result. Materialize the dilated base via a strided slice_update, then the
+    // rest of the pooling path treats it like an ordinary (base_dil == 1) input.
+    mlx::core::array base = *input;
+    // allBaseDilOne is true whenever baseDilOpt is empty, so reaching here with
+    // !allBaseDilOne guarantees a value; the explicit check keeps clang-tidy's
+    // optional-access analysis happy.
+    if (!allBaseDilOne && baseDilOpt) {
+        auto* init = RequireValue(values, rwOp.getInitValues()[0], "stablehlo.reduce_window");
+        if (!init)
+            return false;
+
+        std::vector<int64_t> baseDil(rank, 1);
+        auto bd = *baseDilOpt;
+        for (int64_t i = 0; i < rank; i++)
+            baseDil[i] = bd[i];
+
+        mlx::core::Shape dilShape(rank);
+        mlx::core::Shape startIdx(rank, 0);
+        mlx::core::Shape stopIdx(rank);
+        mlx::core::Shape strideIdx(rank);
+        for (int64_t i = 0; i < rank; i++) {
+            // Runtime shape so dynamically-shaped operands stay correct.
+            int dim = input->shape(static_cast<int>(i));
+            dilShape[i] = (dim - 1) * static_cast<int>(baseDil[i]) + 1;
+            stopIdx[i] = dilShape[i];
+            strideIdx[i] = static_cast<int>(baseDil[i]);
+        }
+
+        mlx::core::array dilated = mlx::core::full(dilShape, *init, input->dtype());
+        base = mlx::core::slice_update(dilated, *input, startIdx, stopIdx, strideIdx);
     }
 
     // For Prod, the StableHLO reduction semantics include the init value as a
@@ -355,8 +386,8 @@ bool HandleReduceWindow(mlir::Operation* op, ValueMap& values,
         }
     }
 
-    // Pad input if needed.
-    mlx::core::array padded = *input;
+    // Pad the (possibly base-dilated) input if needed.
+    mlx::core::array padded = base;
     bool needsPad = false;
     for (int64_t i = 0; i < rank; i++) {
         if (padLow[i] != 0 || padHigh[i] != 0) {
@@ -373,7 +404,7 @@ bool HandleReduceWindow(mlir::Operation* op, ValueMap& values,
         for (int64_t i = 0; i < rank; i++) {
             padWidth[i] = {static_cast<int>(padLow[i]), static_cast<int>(padHigh[i])};
         }
-        padded = mlx::core::pad(*input, padWidth, *init);
+        padded = mlx::core::pad(base, padWidth, *init);
     }
 
     auto paddedShape = padded.shape();

--- a/src/pjrt_plugin/ops/reduction.cc
+++ b/src/pjrt_plugin/ops/reduction.cc
@@ -314,10 +314,13 @@ bool HandleReduceWindow(mlir::Operation* op, ValueMap& values,
 
     // Base dilation: StableHLO dilates the *input* by inserting (base_dil - 1)
     // holes between elements along each axis BEFORE padding and windowing, with
-    // the holes filled by the init value. init is the reduction identity
-    // (0/-inf/+inf/1 for sum/max/min/prod), so the holes never affect the
-    // result. Materialize the dilated base via a strided slice_update, then the
-    // rest of the pooling path treats it like an ordinary (base_dil == 1) input.
+    // the holes filled by the init value -- which is exactly what we do here, so
+    // the fill is faithful to the spec for any init. For the identity inits that
+    // pooling uses (0/-inf/+inf/1 for sum/max/min/prod) the holes are inert;
+    // like the rest of this pooling tier, a non-identity init is not relied on
+    // (and prod's init=1 is checked explicitly above). Materialize the dilated
+    // base via a strided slice_update, then the rest of the pooling path treats
+    // it like an ordinary (base_dil == 1) input.
     mlx::core::array base = *input;
     // allBaseDilOne is true whenever baseDilOpt is empty, so reaching here with
     // !allBaseDilOne guarantees a value; the explicit check keeps clang-tidy's

--- a/tests/configs/reduction.py
+++ b/tests/configs/reduction.py
@@ -172,6 +172,51 @@ def make_reduction_op_configs():
                 lambda key: random.normal(key, (2, 8, 8, 3)),
                 name="maxpool2d-overlapping",
             ),
+            # Base dilation 1D: dilates the *input* by inserting init-valued
+            # holes between elements before windowing. This is what sum-pool
+            # gradients lower to (base_dilation == forward stride).
+            OperationTestConfig(
+                lambda x: lax.reduce_window(
+                    x, 0.0, lax.add, (1, 2), (1, 1), "valid", (1, 2), None
+                ),
+                lambda key: random.normal(key, (2, 5)),
+                name="sumpool1d-base-dilation",
+                # JAX VJP not implemented for base dilation; forward only.
+                differentiable_argnums=(),
+            ),
+            # Base dilation 2D with sum reduction and SAME padding.
+            OperationTestConfig(
+                lambda x: lax.reduce_window(
+                    x,
+                    0.0,
+                    lax.add,
+                    (1, 2, 2, 1),
+                    (1, 1, 1, 1),
+                    "same",
+                    (1, 2, 2, 1),
+                    None,
+                ),
+                lambda key: random.normal(key, (2, 6, 6, 3)),
+                name="sumpool2d-base-dilation-same",
+                differentiable_argnums=(),
+            ),
+            # Base dilation with max reduction (holes filled with init=-inf so
+            # they never win the window).
+            OperationTestConfig(
+                lambda x: lax.reduce_window(
+                    x,
+                    -jnp.inf,
+                    lax.max,
+                    (1, 2, 2, 1),
+                    (1, 1, 1, 1),
+                    "valid",
+                    (1, 2, 2, 1),
+                    None,
+                ),
+                lambda key: random.normal(key, (2, 6, 6, 3)),
+                name="maxpool2d-base-dilation",
+                differentiable_argnums=(),
+            ),
             # Non-square window: 2x3 window
             OperationTestConfig(
                 lambda x: lax.reduce_window(


### PR DESCRIPTION
`reduce_window` with `base_dilation != 1` (emitted by sum-pool gradients) was rejected outright (`reduction.cc`: "base dilations not supported").

## Change
StableHLO base dilation inserts `base_dilation - 1` holes between input elements along each axis **before** padding/windowing, filled with the reduction init value. This PR materializes the dilated base with a strided `mlx::core::slice_update` into a `full(init)` array, then runs the existing pooling path on it. Since `init` is the reduction identity (`0`/`-inf`/`+inf`/`1` for sum/max/min/prod), the holes never affect the result.

Adds base-dilation `OperationTestConfig`s (sum 1D, sum 2D SAME, max 2D).

## Validation
- New `*-base-dilation` configs: 8/8 pass; full reduction op suite green (196 passed); no regressions.
- Upstream: previously-failing `reduce_window` grad tests that lower to base dilation now pass (e.g. `lax_autodiff_test::testReduceWindowGrad1`).

## Scope
Covers single-operand base dilation. **Variadic** (multi-operand) `reduce_window` (`testReduceWindowVariadic*` — independent multi-reduction + argmax-companion patterns) remains unsupported, left for a follow-up. Badge intentionally NOT updated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)