### PR TITLE
fix(dot_general): handle rank-0 (scalar) operands

### DIFF
--- a/src/pjrt_plugin/ops/linalg.cc
+++ b/src/pjrt_plugin/ops/linalg.cc
@@ -118,6 +118,22 @@ bool HandleDotGeneral(mlir::Operation* op, ValueMap& values, std::vector<mlx::co
     mlx::core::array lhsVal = lhsNeedsCast ? mlx::core::astype(*lhs, mlx::core::float32) : *lhs;
     mlx::core::array rhsVal = rhsNeedsCast ? mlx::core::astype(*rhs, mlx::core::float32) : *rhs;
 
+    // Degenerate case: a rank-0 operand. A scalar has no dimensions to batch or
+    // contract over, and StableHLO requires the batch/contract dim lists of the
+    // two operands to have equal length -- so if either operand is rank-0 there
+    // are no batch and no contracting dims at all, and the op reduces to a pure
+    // outer product. With one scalar that is exactly a broadcasting multiply
+    // (the non-scalar operand's free dims, in order, are the output dims). This
+    // also avoids the einsum path, whose subscript would be e.g. ",->" for two
+    // scalars -- a string MLX's einsum parser cannot handle.
+    if (lhsRank == 0 || rhsRank == 0) {
+        auto result = mlx::core::multiply(lhsVal, rhsVal);
+        if (needsCast)
+            result = mlx::core::astype(result, *resultDtype);
+        values.emplace(ToKey(op->getResult(0)), std::move(result));
+        return true;
+    }
+
     // Try einsum path if enabled
     if (UseEinsumForDotGeneral()) {
         std::string subscript = BuildEinsumSubscript(lhsRank, rhsRank, lhsBatchDims, rhsBatchDims,

--- a/tests/configs/matmul.py
+++ b/tests/configs/matmul.py
@@ -181,6 +181,34 @@ def make_matmul_op_configs():
             name="outer_product",
         )
 
+        # Scalar . scalar (rank-0 operands): no batch/contract dims possible, so
+        # dot_general degenerates to a plain product. The einsum subscript for
+        # this case is ",->" which MLX cannot parse; the handler special-cases it
+        # to a broadcasting multiply. Regression test for the scalar dot bug that
+        # surfaced in remat/custom_jvp tests.
+        yield OperationTestConfig(
+            lambda x, y: lax.dot_general(x, y, dimension_numbers=(([], []), ([], []))),
+            lambda key: random.normal(key, ()),
+            lambda key: random.normal(key, ()),
+            name="dot_general_scalar_scalar",
+        )
+
+        # Scalar . vector outer product: rank-0 lhs, rank-1 rhs -> scaled vector.
+        yield OperationTestConfig(
+            lambda x, y: lax.dot_general(x, y, dimension_numbers=(([], []), ([], []))),
+            lambda key: random.normal(key, ()),
+            lambda key: random.normal(key, (4,)),
+            name="dot_general_scalar_vector",
+        )
+
+        # Matrix . scalar outer product: rank-2 lhs, rank-0 rhs -> scaled matrix.
+        yield OperationTestConfig(
+            lambda x, y: lax.dot_general(x, y, dimension_numbers=(([], []), ([], []))),
+            lambda key: random.normal(key, (3, 4)),
+            lambda key: random.normal(key, ()),
+            name="dot_general_matrix_scalar",
+        )
+
         # Edge case: zero batch size (empty batch dimension)
         # CPU handles this correctly, returning empty arrays with the right shape.
         yield OperationTestConfig(


### PR DESCRIPTION
## What

Fix `stablehlo.dot_general` when either operand is rank-0 (a scalar).

## Why

A scalar operand has no dimensions to batch or contract over, and StableHLO requires the two operands' batch and contracting dimension lists to have equal length — so whenever either operand is rank-0 there are **no** batch and **no** contracting dims, and `dot_general` reduces to a pure outer product. With one scalar that is exactly a broadcasting multiply.

The einsum lowering produced a degenerate subscript for these cases (e.g. `",->"` for scalar · scalar), which MLX's einsum parser rejects:

```
[einsum] Number of operands, 2, does not match number of input subscripts, 1
```

so the op emitted no output and the executable failed with an output-count mismatch. This surfaced in remat / `custom_jvp` / `custom_vjp` tests whose backward pass forms a scalar dot.

## How

- `src/pjrt_plugin/ops/linalg.cc`: special-case `lhsRank == 0 || rhsRank == 0` to `mlx::core::multiply` (with the existing integer→float cast-back), before the einsum path.
- `tests/configs/matmul.py`: add `dot_general_scalar_scalar`, `dot_general_scalar_vector`, and `dot_general_matrix_scalar` configs.

## Verification

- New configs pass; full matmul/dot_general config group green.
- Forward and gradient values verified against expected (scalar·scalar, scalar·vector, matrix·scalar).
- Upstream `api_test.py::…::test_remat_custom_jvp_policy` and `test_remat_custom_vjp_policy` now pass on the MPS backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)