### PR TITLE
fix(control_flow): compile nested stablehlo.case (case-selected-by-case)

### DIFF
--- a/src/pjrt_plugin/ops/control_flow.cc
+++ b/src/pjrt_plugin/ops/control_flow.cc
@@ -782,21 +782,19 @@ bool HandleCase(mlir::Operation* op, ValueMap& values, std::vector<mlx::core::ar
             }
         }
 
-        // Fallback: add the index directly. This is safe when:
-        // (a) the index has no defining op (block argument — mx::compile
-        //     will re-substitute), or
-        // (b) the index is a stablehlo.constant (compile-time literal that
-        //     never changes across replays, so freezing is correct).
-        // Any other defining op is an unrecognized intermediate that would
-        // be frozen under mx::compile, silently selecting the wrong branch.
+        // Fallback: pass the index through directly as a primitive input. Like
+        // every other CasePrimitive input, it is wired via make_arrays() as an
+        // explicit graph edge, so mx::compile recomputes it on each replay — it
+        // is never frozen as a compile-time constant. This is the same property
+        // that makes WhileLoopPrimitive's external captures safe (see the note
+        // in HandleWhile), and it holds for an arbitrary index-defining op,
+        // including a nested stablehlo.case whose result selects this case (the
+        // pattern NUTS generates). The clamp/convert decomposition above is a
+        // cheaper optimization that taps the raw function argument; this
+        // fallback covers every other shape. CasePrimitive::eval_impl
+        // bounds-checks the index (out-of-range selects the last branch per the
+        // StableHLO spec), so passing it unclamped here is safe.
         if (indexArgPos == SIZE_MAX) {
-            if (indexDefOp && !mlir::isa<mlir::stablehlo::ConstantOp>(indexDefOp)) {
-                MPS_LOG_ERROR(
-                    "HandleCase: unrecognized index pattern (defined by %s), "
-                    "cannot safely compile\n",
-                    indexDefOp->getName().getStringRef().str().c_str());
-                return false;
-            }
             indexArgPos = extArrays.size();
             extKeys.push_back(ToKey(indexVal));
             extArrays.push_back(*index);

--- a/tests/test_control_flow_compile.py
+++ b/tests/test_control_flow_compile.py
@@ -1,0 +1,87 @@
+"""Regression test: nested ``stablehlo.case`` must take the MLX compile path.
+
+A ``case`` (from ``lax.cond`` / ``lax.switch``) whose selector is itself produced
+by another ``case`` — a pattern NumPyro's NUTS sampler generates — used to bail
+the MLX compile path in ``HandleCase`` with "unrecognized index pattern" and
+silently fall back to the slower eager execution path. The selector is passed to
+``CasePrimitive`` as a ``make_arrays()`` graph edge, so it is recomputed on every
+replay (never frozen) — the same property that makes ``WhileLoopPrimitive``'s
+external captures safe — so the bail was unnecessary.
+
+This is not a correctness failure (the eager fallback produces correct results);
+the regression is that the compile path is abandoned. We assert the bail message
+does not appear, and that inference still produces finite, sane results without
+deadlocking (a real risk for these re-entrant control-flow primitives).
+"""
+
+from __future__ import annotations
+
+import jax
+import numpy as np
+import pytest
+
+try:
+    MPS_DEVICE = jax.devices("mps")[0]
+except (RuntimeError, IndexError):
+    MPS_DEVICE = None
+
+# NumPyro is the reliable source of the nested-case pattern (it survives JAX's
+# own folding and only loses its index clamp in our simplification pass).
+numpyro = pytest.importorskip("numpyro")
+
+pytestmark = pytest.mark.skipif(MPS_DEVICE is None, reason="MPS device required")
+
+# Substring of the HandleCase compile-path bail (control_flow.cc). Its presence
+# means a case fell back to eager instead of compiling.
+_BAIL_MESSAGE = "unrecognized index pattern"
+
+
+def _run_gp_nuts():
+    """Tiny GP regression with NUTS; the kernel cholesky + NUTS integrator
+    produce a ``case``-selects-``case`` graph. Returns posterior samples."""
+    import jax.numpy as jnp
+    import numpyro.distributions as dist
+    from numpyro.infer import MCMC, NUTS
+
+    rng = np.random.default_rng(0)
+    n = 12
+    x = np.sort(rng.random(n)).astype(np.float32)
+    y = (np.sin(3 * x) + 0.1 * rng.standard_normal(n)).astype(np.float32)
+
+    def model(x, y=None):
+        var = numpyro.sample("var", dist.LogNormal(0.0, 1.0))
+        ls = numpyro.sample("ls", dist.LogNormal(0.0, 1.0))
+        noise = numpyro.sample("noise", dist.HalfNormal(0.5))
+        d = (x[:, None] - x[None, :]) ** 2
+        k = var * jnp.exp(-0.5 * d / ls**2) + (noise + 1e-5) * jnp.eye(n)
+        numpyro.sample(
+            "y",
+            dist.MultivariateNormal(
+                loc=jnp.zeros(n), scale_tril=jnp.linalg.cholesky(k)
+            ),
+            obs=y,
+        )
+
+    mcmc = MCMC(
+        NUTS(model), num_warmup=5, num_samples=5, num_chains=1, progress_bar=False
+    )
+    mcmc.run(jax.random.key(0), x, y)
+    return mcmc.get_samples()
+
+
+@pytest.mark.timeout(180)
+def test_nested_case_compiles(capfd):
+    """A nested ``stablehlo.case`` must compile rather than bail to eager."""
+    samples = _run_gp_nuts()
+    captured = capfd.readouterr()
+
+    # Inference must produce finite posterior samples (correctness + no deadlock;
+    # a deadlock would trip the timeout above).
+    for name, value in samples.items():
+        assert np.all(np.isfinite(np.asarray(value))), f"non-finite samples: {name}"
+
+    # The compile-path bail must not fire: the nested case should compile.
+    assert _BAIL_MESSAGE not in captured.err, (
+        "nested stablehlo.case fell back to eager execution (compile bail):\n"
+        f"{captured.err}"
+    )


### PR DESCRIPTION
## What

Make `HandleCase`'s MLX compile path handle a `case` whose **selector is produced by another `case`** (case-selected-by-case), instead of bailing to eager.

## Why

`HandleCase` only recognized a case index defined by `clamp(arg)` / `convert(arg)` / a function argument / a constant. When the index is produced by another `case` — the pattern NumPyro's NUTS sampler generates, once our simplification pass drops the redundant index clamp — it bailed with:

```
[MPS ERROR] HandleCase: unrecognized index pattern (defined by stablehlo.case), cannot safely compile
```

returning `false`. That aborts the whole top-level `mx::compile`, silently dropping the executable to the **eager** path: correct results, but no compiled execution and an alarming `[MPS ERROR]` on every such graph (e.g. every NUTS inference loop).

## Why the bail was unnecessary

The index is wired into `CasePrimitive` via `make_arrays()` as an explicit **graph edge**, so `mx::compile` recomputes it on every replay — it is *never* frozen as a compile-time constant. This is the same property the `WhileLoopPrimitive` note already documents for its external captures (`control_flow.cc:386-392`), and it holds for an arbitrary index-defining op, including a nested `case`. `CasePrimitive::eval_impl` already bounds-checks the index (out-of-range → last branch, per the StableHLO spec), so passing it unclamped is safe.

## How

Drop the bail; pass any unrecognized index straight through as a primitive input. The clamp/convert decomposition above it stays as a cheaper optimization for the common shapes.

## Validation

Given the deadlock history of these re-entrant control-flow primitives (WhileLoopPrimitive was reverted in #137 and re-landed in #142), this was validated carefully on a GP-NUTS model (the reliable reproducer):

- **Correctness / no freezing**: the compile path now selects branches **identically to eager** — `MPS_NO_COMPILE=1` and the compiled path produce byte-identical posteriors. (A frozen index would diverge.)
- **No deadlock** under `JAX_MPS_ASYNC_DISPATCH=1` (the historically deadlock-prone mode), with a hard hang-watchdog.
- 690 control-flow / scan / cond / switch / while / fori / sort / reduction / numpyro tests pass; no regressions.

## Test

`tests/test_control_flow_compile.py` (new, behavioral — same spirit as `test_fusion.py`): runs a small GP-NUTS model and asserts the nested case **compiles** (no bail message in stderr) and inference stays finite without deadlocking (timeout-guarded). This is red before the fix, green after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)