### PR TITLE
feat(control_flow): support tokens (create_token / after_all)

### DIFF
--- a/src/pjrt_plugin/ops/control_flow.cc
+++ b/src/pjrt_plugin/ops/control_flow.cc
@@ -1657,6 +1657,29 @@ bool HandleComposite(mlir::Operation* op, ValueMap& values, std::vector<mlx::cor
 }
 
 // Handler for stablehlo.optimization_barrier
+// Handlers for stablehlo.create_token / stablehlo.after_all.
+//
+// A token (!stablehlo.token) carries no data — it only threads execution
+// ordering between side-effecting ops. The MPS backend executes a module's ops
+// in program order, so the ordering is already implied; we just need a value to
+// stand in for the token wherever it flows (notably as a jit function result or
+// argument). We represent it as a trivial scalar placeholder. Output marshalling
+// already maps non-tensor results to an f32 scalar buffer (see MlxExecutable),
+// and input binding is by position, so a token round-trips as that scalar.
+bool HandleCreateToken(mlir::Operation* op, ValueMap& values,
+                       std::vector<mlx::core::array>& outputs, ExecContext& ctx) {
+    values.emplace(ToKey(op->getResult(0)), mlx::core::array(0.0F));
+    return true;
+}
+
+// after_all merges N input tokens into one. Tokens carry no data, so the merged
+// token is just a fresh placeholder; the operand tokens are ignored.
+bool HandleAfterAll(mlir::Operation* op, ValueMap& values, std::vector<mlx::core::array>& outputs,
+                    ExecContext& ctx) {
+    values.emplace(ToKey(op->getResult(0)), mlx::core::array(0.0F));
+    return true;
+}
+
 bool HandleOptimizationBarrier(mlir::Operation* op, ValueMap& values,
                                std::vector<mlx::core::array>& outputs, ExecContext& ctx) {
     for (unsigned i = 0; i < op->getNumResults(); ++i) {
@@ -1741,6 +1764,8 @@ void RegisterControlFlowHandlers(std::unordered_map<std::string, OpHandler>& han
     handlers.insert({"stablehlo.while", HandleWhile});
     handlers.insert({"stablehlo.case", HandleCase});
     handlers.insert({"stablehlo.rng_bit_generator", HandleRngBitGenerator});
+    handlers.insert({"stablehlo.create_token", HandleCreateToken});
+    handlers.insert({"stablehlo.after_all", HandleAfterAll});
 }
 
 }  // namespace jax_mps

--- a/src/pjrt_plugin/ops/control_flow.cc
+++ b/src/pjrt_plugin/ops/control_flow.cc
@@ -1656,7 +1656,6 @@ bool HandleComposite(mlir::Operation* op, ValueMap& values, std::vector<mlx::cor
     return true;
 }
 
-// Handler for stablehlo.optimization_barrier
 // Handlers for stablehlo.create_token / stablehlo.after_all.
 //
 // A token (!stablehlo.token) carries no data — it only threads execution
@@ -1680,6 +1679,7 @@ bool HandleAfterAll(mlir::Operation* op, ValueMap& values, std::vector<mlx::core
     return true;
 }
 
+// Handler for stablehlo.optimization_barrier
 bool HandleOptimizationBarrier(mlir::Operation* op, ValueMap& values,
                                std::vector<mlx::core::array>& outputs, ExecContext& ctx) {
     for (unsigned i = 0; i < op->getNumResults(); ++i) {

--- a/tests/test_control_flow_compile.py
+++ b/tests/test_control_flow_compile.py
@@ -122,12 +122,19 @@ def test_token_threaded_with_real_output():
     assert float(out) == 4.0
 
 
-def test_grad_through_token_consuming():
-    """Differentiation past a token-consuming primitive must work."""
+def test_grad_with_live_token():
+    """Differentiating a jitted fn that keeps a token live must work.
+
+    The token is returned as an aux output (``has_aux``) so it survives DCE and
+    actually appears in the differentiated, jitted graph — exercising the token
+    handlers in that context — while the gradient is taken w.r.t. the real loss.
+    """
     import jax.numpy as jnp
 
     def f(x):
-        jax.lax.create_token()
-        return x * 2.0
+        return x * x, jax.lax.after_all(jax.lax.create_token())
 
-    assert float(jax.grad(f)(jnp.float32(2.0))) == 2.0
+    value_and_grad = jax.jit(jax.value_and_grad(f, has_aux=True))
+    (value, _token), grad = value_and_grad(jnp.float32(3.0))
+    assert float(value) == 9.0
+    assert float(grad) == 6.0

--- a/tests/test_control_flow_compile.py
+++ b/tests/test_control_flow_compile.py
@@ -20,6 +20,8 @@ import jax
 import numpy as np
 import pytest
 
+from .configs import OperationTestConfig
+
 try:
     MPS_DEVICE = jax.devices("mps")[0]
 except (RuntimeError, IndexError):
@@ -85,3 +87,47 @@ def test_nested_case_compiles(capfd):
         "nested stablehlo.case fell back to eager execution (compile bail):\n"
         f"{captured.err}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Tokens (stablehlo.create_token / after_all)
+# ---------------------------------------------------------------------------
+# A token (!stablehlo.token) carries no data; it only threads effect ordering,
+# and surfaces at the jit boundary as a returned/accepted value. The MPS backend
+# represents it as a trivial scalar placeholder. (Opaque token-buffer semantics —
+# e.g. rejecting numpy conversion — are a separate, deliberately out-of-scope
+# follow-up.)
+
+
+def test_jit_returning_token():
+    """A jit that returns a token must run (create_token is handled)."""
+    # Tokens are opaque (no comparable value) and get DCE'd when disconnected,
+    # so they can't be exercised via an OperationTestConfig value check; mark
+    # them exercised here, as test_ops.py does for composite / rng_bit_generator.
+    OperationTestConfig.EXERCISED_STABLEHLO_OPS.add("stablehlo.create_token")
+    OperationTestConfig.EXERCISED_STABLEHLO_OPS.add("stablehlo.after_all")
+    tok = jax.jit(jax.lax.create_token)()
+    # And the token round-trips as a jit argument (after_all consumes it).
+    jax.block_until_ready(jax.jit(lambda t: jax.lax.after_all(t))(tok))
+
+
+def test_token_threaded_with_real_output():
+    """A token threaded alongside a real result must not disturb the result."""
+    import jax.numpy as jnp
+
+    def f(x):
+        return x + 1.0, jax.lax.after_all(jax.lax.create_token())
+
+    out, _tok = jax.jit(f)(jnp.float32(3.0))
+    assert float(out) == 4.0
+
+
+def test_grad_through_token_consuming():
+    """Differentiation past a token-consuming primitive must work."""
+    import jax.numpy as jnp
+
+    def f(x):
+        jax.lax.create_token()
+        return x * 2.0
+
+    assert float(jax.grad(f)(jnp.float32(2.0))) == 2.0


### PR DESCRIPTION
## What

Add handlers for `stablehlo.create_token` and `stablehlo.after_all`, completing the structural/control-flow primitive set (the last one missing alongside `while`/`case`/`reduce`/`scatter`/...).

## Why

A token (`!stablehlo.token`) carries no data — it threads *effect ordering* between side-effecting ops and surfaces at the jit boundary as a returned/accepted value (`lax.create_token`/`after_all`, ordered effects). The MPS backend had no handler, so any computation that **returns, accepts, or threads** a token failed with `Unsupported operation(s): stablehlo.create_token`.

## How

The MPS backend executes a module's ops in program order, so the ordering a token expresses is already implied — we only need a stand-in value wherever the token flows. Represent it as a **trivial scalar placeholder**: `create_token` mints one, `after_all` merges its inputs into a fresh one. Output marshalling already maps non-tensor results to an f32 scalar buffer, and input binding is by position, so a token round-trips through the jit boundary as that scalar. ~10 lines + registration.

## Scope

Fixes the **practically useful** cases:
- jit returning a token, accepting a token as input, threading a token alongside real results, and grad through a token-consuming primitive (4–5 upstream tests).

**Deliberately out of scope** (the tail): opaque token-*buffer* semantics — e.g. `test_print_token_buffer_error` expects converting a token buffer to numpy to raise. That needs real PJRT `TOKEN`-buffer plumbing (a buffer whose type is distinct from its backing array and rejects host conversion) for one error-message test. Left as a follow-up.

## Tests

`tests/test_control_flow_compile.py`: token round-trip / threading / grad-through behavioral tests. Tokens are opaque (no comparable value) and DCE'd when disconnected, so they can't be value-tested via an `OperationTestConfig`; they're marked exercised explicitly, mirroring how `test_ops.py` handles `composite` / `rng_bit_generator`. Control-flow suite green (100 passed); full op-coverage check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)