### PR TITLE
perf(softmax): strip trivial reshapes to allow `fused_softmax` on size-1 axes

### DIFF
--- a/src/pjrt_plugin/passes/fuse_softmax.cc
+++ b/src/pjrt_plugin/passes/fuse_softmax.cc
@@ -99,6 +99,7 @@ Value stripNegInfMaximum(Value v) {
         return v;
 
     auto isNegInf = [](Value cand) -> bool {
+        cand = stripTrivialReshapes(cand);
         if (auto bc = cand.getDefiningOp<stablehlo::BroadcastInDimOp>())
             cand = bc.getOperand();
         mlir::DenseElementsAttr attr;

--- a/tests/configs/fusion.py
+++ b/tests/configs/fusion.py
@@ -154,7 +154,7 @@ def make_fusion_configs() -> list[FusionTestConfig]:
     # --- fuse_softmax: reduce_max/sub/exp/reduce_sum/divide -> mps.softmax ---
 
     # Trailing-axis softmax at several ranks & shapes.
-    for shape in [(8,), (4, 16), (2, 3, 12), (2, 4, 8, 32)]:
+    for shape in [(8,), (1, 8), (4, 16), (2, 3, 12), (2, 4, 8, 32), (1, 1, 1, 8)]:
         configs.append(
             FusionTestConfig(
                 name=f"softmax.trailing.{'x'.join(map(str, shape))}",


### PR DESCRIPTION
Fixes #200.

Earlier, the pattern matcher could identify:
```
maximum(broadcast(-inf), reduce_max)
          |
          recognized as -inf
```
for all tensor shapes without size-1 axes. 

StableHLO spec [says](https://openxla.org/stablehlo/generated/stablehlo_optimization_passes#-stablehlo-aggressive-simplification) that a `broadcast_in_dim` must become a `reshape` if number of elements is the same (which is true when `-inf` is "broadcasted" to a new tensor with size-1 axes).

```
maximum(reshape(-inf), reduce_max)
          |
          not recognized as -inf => no fusion
```

This PR strips trivial reshapes on the operand to allow pattern matching.

Tests updated for the same.
