### PR TITLE
fix(control-flow): unencodable fused kernels, swallowed stream-thread exceptions, readback races

### DIFF
--- a/src/pjrt_plugin/mlx_executable.cc
+++ b/src/pjrt_plugin/mlx_executable.cc
@@ -7,6 +7,7 @@
 #include <mlx/memory.h>
 #include <mlx/mlx.h>
 #include <mlx/primitives.h>
+#include <mlx/scheduler.h>
 
 #include <cctype>
 #include <chrono>
@@ -870,6 +871,16 @@ MlxExecuteResult MlxExecutable::Execute(const std::vector<MlxBuffer*>& inputs) {
                 auto test_outputs = compiled_fn_(inputArrays);
                 if (!test_outputs.empty()) {
                     mlx::core::eval(test_outputs);
+                    // An exception thrown by a primitive's eval on a stream
+                    // worker thread is caught there (MLX patch 10) and parked;
+                    // eval() above can complete without traversing an
+                    // array::wait() that would rethrow it. Probe explicitly so
+                    // a failed trace run triggers the catch below (falling back
+                    // to the eager path) instead of returning outputs whose
+                    // producing task died — i.e. never-written buffers. Also
+                    // consumes the parked exception so it cannot poison the
+                    // eager fallback run.
+                    mlx::core::scheduler::rethrow_pending_exception();
                     compile_succeeded_ = true;
                     outputs = std::move(test_outputs);
                     MPS_LOG_INFO("MLX compile() succeeded - using compiled execution path\n");
@@ -933,6 +944,14 @@ MlxExecuteResult MlxExecutable::Execute(const std::vector<MlxBuffer*>& inputs) {
             } else {
                 mlx::core::eval(outputs);
             }
+            // Surface exceptions parked by stream worker threads (MLX patch
+            // 10) that the eval above did not traverse an array::wait() for.
+            // Without this, a primitive whose eval threw (e.g. an unencodable
+            // kernel) leaves its outputs as never-written buffers and the
+            // Execute "succeeds" with garbage. Async note: work still in
+            // flight after async_eval surfaces later parked exceptions at the
+            // buffer/event wait, which goes through array::wait().
+            mlx::core::scheduler::rethrow_pending_exception();
         } catch (const std::exception& e) {
             MPS_LOG_ERROR("MLX evaluation failed: %s\n", e.what());
             result.error_message = std::string("eval: ") + e.what();

--- a/src/pjrt_plugin/ops/control_flow.cc
+++ b/src/pjrt_plugin/ops/control_flow.cc
@@ -7,6 +7,7 @@
 #include <mlx/ops.h>
 #include <mlx/primitives.h>
 #include <mlx/random.h>
+#include <mlx/scheduler.h>
 #include <mlx/transforms.h>
 
 #include <algorithm>
@@ -29,6 +30,21 @@
 namespace jax_mps {
 
 namespace {
+
+// Complete all in-flight GPU work before a control-flow primitive touches
+// its inputs (jax-mps#195). WhileLoopPrimitive / CasePrimitive run on the
+// CPU stream *inside* an enclosing eval pass; their inputs typically have
+// status == evaluated, which only means the producing kernels were ENCODED —
+// the GPU command buffer may not have been committed, let alone completed.
+// MLX's eval fences only inputs that were unscheduled within the same pass,
+// so nothing orders the primitive's re-entrant evals and scalar readbacks
+// (case index, while cond, trip count) after the producing GPU work. The
+// race was caught red-handed on the jax-mps#195 MRE: the case branch index
+// read garbage (e.g. 73, or a float bit-pattern) before a GPU sync and the
+// true 0/1 after, silently selecting the wrong branch.
+void SyncGpuStream() {
+    mlx::core::synchronize(mlx::core::default_stream(mlx::core::Device::gpu));
+}
 
 // Shared unary op table used by both the mhlo.* custom_call path (HandleCustomCall)
 // and the chlo.* composite path (HandleComposite). Keyed by the bare op name as a
@@ -424,6 +440,11 @@ public:
 private:
     void eval_impl(const std::vector<mlx::core::array>& inputs,
                    std::vector<mlx::core::array>& outputs) {
+        // Order this loop's readbacks and body evals after all in-flight GPU
+        // work (see SyncGpuStream): the trip-count scalars and the first
+        // iteration's body read the primitive's inputs, which the enclosing
+        // eval pass may still be producing.
+        SyncGpuStream();
         // inputs = loopVars (nLoopVars_) + external values (nExt_)
         std::vector<mlx::core::array> current(inputs.begin(), inputs.end());
 
@@ -474,6 +495,10 @@ private:
                         mlx::core::eval(vars);
                     else
                         mlx::core::async_eval(vars);
+                    // Surface exceptions parked by stream worker threads (MLX
+                    // patch 10): a failed body kernel otherwise feeds garbage
+                    // into subsequent iterations while the error stays hidden.
+                    mlx::core::scheduler::rethrow_pending_exception();
                 }
             }
         } else {
@@ -497,6 +522,10 @@ private:
                 // Synchronous eval — bounded graph, no accumulation, safe
                 // re-entry for nested WhileLoopPrimitives.
                 mlx::core::eval(combined);
+                // Surface parked stream-thread exceptions before reading the
+                // cond scalar: a failed body kernel would otherwise yield a
+                // garbage condition and can spin the loop indefinitely.
+                mlx::core::scheduler::rethrow_pending_exception();
 
                 // Update loop vars from combined[1..nLoopVars]
                 for (size_t j = 0; j < nLoopVars_; ++j)
@@ -511,6 +540,7 @@ private:
         std::vector<mlx::core::array> finalVars(current.begin(),
                                                 current.begin() + static_cast<Diff>(nLoopVars_));
         mlx::core::eval(finalVars);
+        mlx::core::scheduler::rethrow_pending_exception();
 
         for (size_t i = 0; i < nLoopVars_; ++i)
             outputs[i].copy_shared_buffer(current[i]);
@@ -626,6 +656,10 @@ private:
             throw std::runtime_error("CasePrimitive: expected " + std::to_string(nExt_) +
                                      " inputs, got " + std::to_string(inputs.size()));
 
+        // Order the index readback and branch eval after all in-flight GPU
+        // work (see SyncGpuStream): both read this primitive's inputs, which
+        // the enclosing eval pass may still be producing (jax-mps#195).
+        SyncGpuStream();
         // Evaluate the index via the compiled index function.
         // This correctly re-computes the index from function arguments at
         // runtime, avoiding stale values from mx::compile's graph caching.
@@ -649,6 +683,9 @@ private:
 
         // Synchronous eval — single branch execution, bounded graph.
         mlx::core::eval(branchResults);
+        // Surface parked stream-thread exceptions (MLX patch 10) instead of
+        // copying never-written buffers into the case outputs.
+        mlx::core::scheduler::rethrow_pending_exception();
 
         for (size_t i = 0; i < nOutputs_; ++i)
             outputs[i].copy_shared_buffer(branchResults[i]);

--- a/tests/configs/control_flow.py
+++ b/tests/configs/control_flow.py
@@ -261,6 +261,31 @@ def make_control_flow_op_configs():
                 differentiable_argnums=(),
                 name="lax.while_loop.one_iter",
             ),
+            # Many live carries: the compiled body+cond function emits fused
+            # elementwise segments with ~30 outputs. MLX must split these to
+            # respect Metal's 31-argument-buffer kernel limit (vendored MLX
+            # patch 13); before that guard, fusion produced an unencodable
+            # kernel whose eval-time throw on a stream worker thread was
+            # swallowed, silently leaving the loop outputs as never-written
+            # buffers (the numpyro.Binomial first-call corruption).
+            OperationTestConfig(
+                lambda init: sum(
+                    lax.while_loop(
+                        lambda state: state[0] < 3,
+                        lambda state: (
+                            (state[0] + 1,)
+                            + tuple(
+                                x + (state[1] * 0.5 + 1.0) * (k + 1)
+                                for k, x in enumerate(state[1:])
+                            )
+                        ),
+                        (numpy.int32(0),) + tuple(init + k for k in range(28)),
+                    )[1:]
+                ),
+                numpy.linspace(0.0, 1.0, 4, dtype=numpy.float32),
+                differentiable_argnums=(),
+                name="lax.while_loop.many_carries",
+            ),
             # Array operations along axis 1
             OperationTestConfig(
                 lambda init: lax.while_loop(
@@ -425,12 +450,10 @@ def make_control_flow_op_configs():
                     x,
                 ),
                 numpy.float32(1.0),
-                # Grad through fori+nested cond produces nondeterministic wrong
-                # values on MPS — pre-existing miscompile also present on main
-                # (branch residuals appear to be dropped in the backward pass),
-                # unrelated to the counted-loop fast path. Tracked in issue #195;
-                # enabling grads here is the regression test once fixed.
-                differentiable_argnums=(),
+                # Grads exercise the issue-#195 fix: the backward scan's
+                # nested-cond branch index was read before the GPU work
+                # producing it completed (control-flow primitives now
+                # synchronize the GPU stream at eval entry).
                 name="lax.fori_loop.long_nested_cond",
             ),
             # fori_loop with a traced (runtime) upper bound — the while cond's

--- a/third_party/mlx/patches/13-compile-fuse-buffer-budget.patch
+++ b/third_party/mlx/patches/13-compile-fuse-buffer-budget.patch
@@ -1,0 +1,67 @@
+Enforce the Metal argument-buffer budget at fusion time.
+
+mx::compile's greedy kernel fusion (compile_fuse) bounds only the number
+of segment INPUTS (max_compile_arrays, leakily), but the generated Metal
+kernel binds non-constant inputs AND outputs AND up to three auxiliary
+buffers (in_strides, output_shape/size, ndim) against Metal's 31-buffer
+limit. A segment with many outputs (e.g. a compiled while-loop body whose
+loop carries and cond intermediates are all segment outputs) produces a
+kernel that backend/metal/compiled.cpp rejects with "[compile] Too many
+inputs/outputs fused in the Metal Compiled primitive ..." -- but only at
+EVAL time, on a stream worker thread. In jax-mps that exception is caught
+by the scheduler (patch 10) and can be effectively swallowed by fallback
+paths, leaving the primitive's outputs as never-written buffers: silent
+nondeterministic garbage instead of an error (jax-mps#170, #195, and the
+numpyro.Binomial first-call corruption found while fixing #196).
+
+This patch computes the worst-case buffer count when the segment is
+finalized and skips fusing the segment root if it cannot be encoded. The
+interior nodes are revisited later in the reverse-tape walk and fuse into
+smaller, encodable segments, so this only splits over-budget kernels.
+
+Candidate for upstreaming (the runtime error message itself asks for an
+issue to be filed).
+
+diff --git a/mlx/compile.cpp b/mlx/compile.cpp
+index 14d1a64..14feacc 100644
+--- a/mlx/compile.cpp
++++ b/mlx/compile.cpp
+@@ -966,6 +966,38 @@ void compile_fuse(
+     };
+     recurse_tape(arr);
+ 
++    // jax-mps: reject fused segments whose Metal kernel cannot be encoded.
++    // The Compiled kernel binds every non-constant input and every output as
++    // an argument buffer, plus up to three auxiliary buffers (in_strides,
++    // output_shape or size, ndim), against Metal's 31-buffer limit (see
++    // backend/metal/compiled.cpp). The greedy segment search above bounds
++    // inputs only, so a segment with many outputs previously produced a
++    // kernel that throws at eval time -- on a stream worker thread, where the
++    // error can be swallowed and the outputs silently left as never-written
++    // buffers (jax-mps#170/#195/#196). Skipping fusion for this root is
++    // always safe: its interior nodes are revisited later in the reverse-tape
++    // walk and fuse into smaller, encodable segments.
++    {
++      int n_outputs = 1; // arr itself is always a segment output
++      for (int j = 0; j + 1 < static_cast<int>(fused_tape.size()); ++j) {
++        if (output_map.find(fused_tape[j].id()) != output_map.end()) {
++          n_outputs++;
++        }
++      }
++      int n_buffers = n_outputs + 3;
++      for (auto& in : inputs) {
++        bool is_const = in.size() == 1 && !in.has_primitive() &&
++            input_ids.find(in.id()) == input_ids.end();
++        if (!is_const) {
++          n_buffers++;
++        }
++      }
++      if (n_buffers > 31) {
++        new_tape.push_back(arr);
++        continue;
++      }
++    }
++
+     std::vector<array> old_outputs;
+     // Add to global cache and add any global outputs to outputs
+     // of new primitive


### PR DESCRIPTION
Three related correctness fixes for control-flow execution on MPS. All were surfaced by a `numpyro.Binomial` reproduction that intermittently returned corrupt samples: the backward scan of a `fori_loop` containing a `lax.cond` was silently selecting the wrong branch.

## 1. MLX patch 13 — bound the fuse budget by the full kernel binding set

`compile_fuse` bounded only the *inputs* of a fused segment, but the emitted Metal kernel binds non-constant inputs **and** outputs **and** up to three auxiliary buffers against Metal's 31-argument-buffer limit. Segments with many outputs (e.g. a compiled while-loop body carrying many values) produced kernels that **throw at eval time**. The patch enforces the true budget at fusion time and splits over-budget segments instead of emitting an unencodable kernel.

## 2. Surface exceptions parked by stream worker threads

An eval-time throw inside a primitive (like the unencodable kernel above) is caught on the stream worker thread (MLX patch 10) and parked — but it was never rethrown on code paths that do not traverse `array::wait()`. `Execute` therefore returned outputs whose producing task had died, i.e. **never-written buffers**, and "succeeded" with garbage. We now probe `scheduler::rethrow_pending_exception()` after the evals in `Execute` and in the while/case primitives, so a failed compiled trace deterministically falls back to the eager path (and the parked exception is consumed so it cannot poison the fallback run).

## 3. Fix #195 — readback race in the while/case primitives

`WhileLoopPrimitive` / `CasePrimitive` run on the CPU stream inside an enclosing eval pass and read scalars (case branch index, loop condition, trip count) from arrays whose producing **GPU** command buffer may not have completed — MLX only fences inputs that were left unscheduled within the same pass. The backward scan of `fori_loop`+`lax.cond` read garbage branch indices (caught red-handed: e.g. `73`, or a float bit-pattern, instead of `0`/`1`), silently selecting the wrong branch. We synchronize the GPU stream at both primitives' eval entry.

### Impact

- The #195 MRE went from **8/8 wrong gradients to 24/24 correct**, including under `JAX_MPS_ASYNC_DISPATCH=1`.
- These three mechanisms (unencodable fused kernels + swallowed stream-thread exceptions + GPU/CPU readback races) are the **leading explanation for the residual intermittency in #170**. This PR likely addresses it, but that should be verified separately — this does not close #170.

### Tests

Gradients enabled on `lax.fori_loop.long_nested_cond` (the #195 regression) and a new `lax.while_loop.many_carries` config that exercises many-output fused segments.

### Performance

The GPU-stream synchronize at the primitive eval entry only affects `lax.cond`-inside-loop-body workloads — a path that was already 40-100x slower than plain loops **and previously returned wrong gradients**:

| workload | before | after |
|---|---|---|
| cond-in-loop forward | 426 us/iter | 562 us/iter |
| cond-in-loop grad | 932 us/iter | 1392 us/iter |
| plain `fori_loop` | 5-7 us/iter | unaffected |
| `jnp.where`-body loop | 11-13 us/iter | unaffected |

### Upstreaming

The fuse-budget guard (patch 13) is a candidate for upstreaming to [ml-explore/mlx](https://github.com/ml-explore/mlx).

Fixes #195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
