### PR TITLE
perf(ops): constant-shift fast path and fusable bitwise handlers (towards #196)

### DIFF
--- a/src/pjrt_plugin/mlx_executable.cc
+++ b/src/pjrt_plugin/mlx_executable.cc
@@ -281,7 +281,19 @@ OpHandler MakeLogicalShiftHandler(const char* opName, BinaryMlxFn shiftFn) {
         auto& lhs = lhs_opt->get();
         auto& rhs = rhs_opt->get();
         int bit_width = static_cast<int>(GetDtypeSize(lhs.dtype()) * 8);
-        auto zero = mlx::core::zeros_like(lhs);
+        // Fast path: in-range compile-time constant shift amount. A single MLX
+        // op instead of the OOB-masking subgraph below — inside compiled loop
+        // bodies every extra graph node is a kernel dispatch, and threefry
+        // (jax.random) uses ~40 constant shifts per key op (jax-mps#196).
+        if (auto amount = GetSplatIntConstant(op->getOperand(1));
+            amount && *amount >= 0 && *amount < bit_width) {
+            values.emplace(ToKey(op->getResult(0)), shiftFn(lhs, rhs, {}));
+            return true;
+        }
+        // General path: mask OOB shift amounts to 0 (StableHLO semantics).
+        // Scalar constant (not zeros_like): a Full node is not fusable by
+        // mx::compile, so it would cost a kernel dispatch per evaluation.
+        auto zero = mlx::core::array(0, lhs.dtype());
         auto oob = mlx::core::logical_or(
             mlx::core::less(rhs, mlx::core::array(0, rhs.dtype())),
             mlx::core::greater_equal(rhs, mlx::core::array(bit_width, rhs.dtype())));

--- a/src/pjrt_plugin/ops/arithmetic.cc
+++ b/src/pjrt_plugin/ops/arithmetic.cc
@@ -5,6 +5,29 @@
 
 namespace jax_mps {
 
+std::optional<int64_t> GetSplatIntConstant(mlir::Value v) {
+    // Look through broadcasts: splat constants commonly reach consumers as
+    // broadcast_in_dim(constant).
+    while (auto bcast = v.getDefiningOp<mlir::stablehlo::BroadcastInDimOp>())
+        v = bcast.getOperand();
+    auto constOp = v.getDefiningOp<mlir::stablehlo::ConstantOp>();
+    if (!constOp)
+        return std::nullopt;
+    auto attr = mlir::dyn_cast<mlir::DenseElementsAttr>(constOp.getValue());
+    if (!attr || !attr.isSplat())
+        return std::nullopt;
+    auto intType = mlir::dyn_cast<mlir::IntegerType>(attr.getElementType());
+    if (!intType)
+        return std::nullopt;
+    llvm::APInt val = attr.getSplatValue<llvm::APInt>();
+    if (intType.isUnsigned()) {
+        if (val.getActiveBits() > 63)
+            return std::nullopt;
+        return static_cast<int64_t>(val.getZExtValue());
+    }
+    return val.getSExtValue();
+}
+
 namespace {
 
 // Handler for stablehlo.clamp
@@ -42,7 +65,9 @@ bool HandleRemainder(mlir::Operation* op, ValueMap& values, std::vector<mlx::cor
         // For signed integers, Python remainder (rounds toward -inf) needs correction
         // to C-style remainder (truncates toward zero)
         auto py_rem = mlx::core::remainder(*a, *b);
-        auto zero = mlx::core::zeros_like(*a);
+        // Scalar constant (not zeros_like): a Full node is not fusable by
+        // mx::compile, so it would cost a kernel dispatch per evaluation.
+        auto zero = mlx::core::array(0, a->dtype());
         auto diff_sign = mlx::core::not_equal(mlx::core::less(*a, zero), mlx::core::less(*b, zero));
         auto needs_fix = mlx::core::logical_and(mlx::core::not_equal(py_rem, zero), diff_sign);
         result = mlx::core::where(needs_fix, mlx::core::subtract(py_rem, *b), py_rem);
@@ -79,9 +104,7 @@ bool HandleNot(mlir::Operation* op, ValueMap& values, std::vector<mlx::core::arr
     if (x->dtype() == mlx::core::bool_) {
         values.emplace(ToKey(op->getResult(0)), mlx::core::logical_not(*x));
     } else {
-        // Bitwise NOT for integers: ~x = x XOR all-ones
-        auto all_ones = mlx::core::full(x->shape(), -1, x->dtype());
-        values.emplace(ToKey(op->getResult(0)), mlx::core::bitwise_xor(*x, all_ones));
+        values.emplace(ToKey(op->getResult(0)), mlx::core::bitwise_invert(*x));
     }
     return true;
 }
@@ -96,15 +119,26 @@ bool HandleShiftRightArithmetic(mlir::Operation* op, ValueMap& values,
     // StableHLO spec: shift < 0 or shift >= bit_width for arithmetic right shift:
     // positive values -> 0, negative values -> -1 (sign bit propagation)
     int bit_width = static_cast<int>(GetDtypeSize(lhs->dtype()) * 8);
+    // Fast path: in-range compile-time constant shift amount. A single MLX op
+    // (right_shift is sign-propagating for signed dtypes) instead of the OOB
+    // subgraph below — inside compiled loop bodies every extra graph node is
+    // a kernel dispatch (jax-mps#196).
+    if (auto amount = GetSplatIntConstant(op->getOperand(1));
+        amount && *amount >= 0 && *amount < bit_width) {
+        values.emplace(ToKey(op->getResult(0)), mlx::core::right_shift(*lhs, *rhs));
+        return true;
+    }
     auto oob = mlx::core::logical_or(
         mlx::core::less(*rhs, mlx::core::array(0, rhs->dtype())),
         mlx::core::greater_equal(*rhs, mlx::core::array(bit_width, rhs->dtype())));
     auto shifted =
         mlx::core::right_shift(*lhs, mlx::core::maximum(*rhs, mlx::core::array(0, rhs->dtype())));
-    // For arithmetic shift, oob result depends on sign: 0 for positive, -1 for negative
-    auto oob_val = mlx::core::where(mlx::core::less(*lhs, mlx::core::array(0, lhs->dtype())),
-                                    mlx::core::full(lhs->shape(), -1, lhs->dtype()),
-                                    mlx::core::zeros_like(*lhs));
+    // For arithmetic shift, oob result depends on sign: 0 for positive, -1 for
+    // negative. Scalar constants (not full/zeros_like): Full nodes are not
+    // fusable by mx::compile, so each would cost a kernel dispatch.
+    auto oob_val =
+        mlx::core::where(mlx::core::less(*lhs, mlx::core::array(0, lhs->dtype())),
+                         mlx::core::array(-1, lhs->dtype()), mlx::core::array(0, lhs->dtype()));
     values.emplace(ToKey(op->getResult(0)), mlx::core::where(oob, oob_val, shifted));
     return true;
 }

--- a/src/pjrt_plugin/ops/handler_utils.h
+++ b/src/pjrt_plugin/ops/handler_utils.h
@@ -146,6 +146,13 @@ OpHandler MakeUnaryHandler(const char* opName, UnaryMlxFn fn);
 OpHandler MakeBinaryHandler(const char* opName, BinaryMlxFn fn);
 OpHandler MakeLogicalShiftHandler(const char* opName, BinaryMlxFn shiftFn);
 
+// Splat integer value of a compile-time constant (looking through
+// broadcast_in_dim), or nullopt if the value is not a splat integer constant.
+// Defined in arithmetic.cc. Lets handlers specialize on constant operands
+// (e.g. in-range shift amounts) and skip emitting defensive subgraphs that
+// cost per-node kernel dispatches inside compiled loop bodies (jax-mps#196).
+std::optional<int64_t> GetSplatIntConstant(mlir::Value v);
+
 // --- Cross-TU functions (defined in mlx_executable.cc, called by control_flow.cc) ---
 
 bool ExecuteRegion(mlir::Region& region, std::vector<mlx::core::array>& args,

--- a/src/pjrt_plugin/ops/sort_fft_complex.cc
+++ b/src/pjrt_plugin/ops/sort_fft_complex.cc
@@ -32,7 +32,7 @@ mlx::core::array DescendingKey(const mlx::core::array& input) {
     }
     // Integer (signed or unsigned): bitwise NOT reverses order without overflow.
     // Unsigned: NOT(0)=MAX, NOT(MAX)=0. Signed: NOT(MIN)=MAX, NOT(MAX)=MIN.
-    return mlx::core::bitwise_xor(input, mlx::core::full({}, -1, dtype));
+    return mlx::core::bitwise_invert(input);
 }
 
 // Compute top-k values and indices along the last axis.

--- a/tests/configs/binary.py
+++ b/tests/configs/binary.py
@@ -283,6 +283,46 @@ def make_binary_op_configs():
                 differentiable_argnums=(),
                 name="lax.shift_right_arithmetic-negative-shift-count",
             ),
+            # Compile-time constant shift amounts exercise the constant fast
+            # path in the shift handlers (single MLX op, no OOB masking).
+            OperationTestConfig(
+                lambda x: lax.shift_left(x, 3),
+                numpy.array([1, 2, -4, 0x40000000], dtype=numpy.int32),
+                differentiable_argnums=(),
+                name="lax.shift_left-constant-count",
+            ),
+            OperationTestConfig(
+                lambda x: lax.shift_right_logical(x, jnp.uint32(7)),
+                numpy.array([1, 128, 0x80000000, 0xFFFFFFFF], dtype=numpy.uint32),
+                differentiable_argnums=(),
+                name="lax.shift_right_logical-constant-count",
+            ),
+            OperationTestConfig(
+                lambda x: lax.shift_right_arithmetic(x, 5),
+                numpy.array([-1024, 1024, -1, 0x7FFFFFFF], dtype=numpy.int32),
+                differentiable_argnums=(),
+                name="lax.shift_right_arithmetic-constant-count",
+            ),
+            # Constant but out-of-bounds shift amounts must fall back to the
+            # masked general path (result 0, or sign fill for arithmetic).
+            OperationTestConfig(
+                lambda x: lax.shift_left(x, 32),
+                numpy.array([1, -2, 0x40000000], dtype=numpy.int32),
+                differentiable_argnums=(),
+                name="lax.shift_left-constant-oob-count",
+            ),
+            OperationTestConfig(
+                lambda x: lax.shift_right_logical(x, jnp.uint32(32)),
+                numpy.array([1, 128, 0xFFFFFFFF], dtype=numpy.uint32),
+                differentiable_argnums=(),
+                name="lax.shift_right_logical-constant-oob-count",
+            ),
+            OperationTestConfig(
+                lambda x: lax.shift_right_arithmetic(x, 32),
+                numpy.array([-1024, 1024, -1, 0], dtype=numpy.int32),
+                differentiable_argnums=(),
+                name="lax.shift_right_arithmetic-constant-oob-count",
+            ),
             # Integer division: truncation toward zero (not float promotion)
             OperationTestConfig(
                 lax.div,


### PR DESCRIPTION
> **Was stacked on #206** (now merged). The denser fusion this change produces is what triggered the unencodable-fused-kernel bug fixed in #206, so that fix had to land first — it has. Rebased onto `main`; now targets `main` directly.

Towards #196: any `jax.random` op inside a loop ran ~30x slower than plain arithmetic. `threefry` lowers to ~140 tiny elementwise StableHLO ops per key op, and the shift handlers expanded **every** shift into 7 MLX nodes including an unfusable `Full` (`zeros_like`) — `mx::compile` can only fuse unary/binary/ternary/broadcast primitives, so each shift cost extra kernel dispatches (~1.5 us each on M-series).

## Changes

- **`shift_left` / `shift_right_logical` / `shift_right_arithmetic`**: when the shift amount is a splat constant in `[0, bit_width)`, emit the single MLX shift op — the OOB masking is statically dead (`GetSplatIntConstant` looks through `broadcast_in_dim`). Dynamic or out-of-range amounts keep the masked path, now built from scalar constants so every node is fusable.
- **`stablehlo.not`** and the sort `DescendingKey` helper use the native, fusable `mlx::core::bitwise_invert` instead of xor with a materialized all-ones.
- **Signed remainder** uses a scalar zero constant instead of `zeros_like`.

## Measurements

On the #196 MWE (`fori_loop` of `jax.random.split`, M-series, idle):

| workload | before | after |
|---|---|---|
| #196 MWE | 190 us/iter | 137 us/iter |
| 120-op rotate-pattern loop body | 210 us/iter | 135 us/iter (now identical to an equivalent xor chain) |

New shift test configs cover constant in-range and constant out-of-range amounts.

Tuning MLX's fusion limits was investigated and **dropped**: a sweep of `max_compile_depth` at 11/24/48/96 showed no benefit (all within the 130–170 us noise band) — the threefry rotate-diamond shape fuses badly regardless of budget. Closing the remaining gap needs a ~10× op-count reduction (intercepting `threefry2x32` as a custom call), not better fusion of the same ops. This does not close #196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

