### PR TITLE
perf(random): fuse threefry2x32 into a single Metal kernel (#196)

### DIFF
--- a/src/jax_plugins/mps/ops.py
+++ b/src/jax_plugins/mps/ops.py
@@ -735,11 +735,11 @@ def _threefry2x32_lowering(ctx, k1, k2, x1, x2):
     if 0 in aval_out.shape:
         zeros = mlir.full_like_aval(ctx, 0, aval_out)
         return [zeros, zeros]
-    out_type = _aval_to_ir_type(aval_out)
     return mlir.custom_call(
         call_target_name="mps.threefry2x32",
-        result_types=[out_type, out_type],
+        result_types=[_aval_to_ir_type(a) for a in ctx.avals_out],
         operands=[k1, k2, x1, x2],
+        backend_config="",
     ).results
 
 

--- a/src/jax_plugins/mps/ops.py
+++ b/src/jax_plugins/mps/ops.py
@@ -11,6 +11,8 @@ decompose to standard JAX ops.
 # pyright: reportArgumentType=false, reportOptionalCall=false
 # pyright: reportFunctionMemberAccess=false, reportCallIssue=false
 
+import warnings
+
 import jax
 import jax.numpy as jnp
 from jax._src import core
@@ -715,6 +717,32 @@ def _make_native_unary_lowering(call_target_name):
     return _lowering
 
 
+def _threefry2x32_lowering(ctx, k1, k2, x1, x2):
+    """MPS lowering for JAX's threefry2x32 PRNG primitive.
+
+    Emits a ``stablehlo.custom_call @mps.threefry2x32`` that the C++ backend
+    dispatches to a single fused Metal kernel, instead of JAX's default inline
+    expansion into ~140 tiny elementwise ops (issue #196). Inside a compiled
+    loop body those ops each cost ~1.5us of dispatch, so a single random.split
+    in a fori_loop body ran ~30x slower than an arithmetic-only body.
+
+    The primitive is elementwise-with-broadcasting over four equal-dtype uint32
+    operands; the backend broadcasts them to the (shared) output shape, so we
+    can hand the operands through unchanged. Only the zero-sized case is special
+    (nothing to hash), mirroring JAX's CUDA lowering.
+    """
+    aval_out, _ = ctx.avals_out
+    if 0 in aval_out.shape:
+        zeros = mlir.full_like_aval(ctx, 0, aval_out)
+        return [zeros, zeros]
+    out_type = _aval_to_ir_type(aval_out)
+    return mlir.custom_call(
+        call_target_name="mps.threefry2x32",
+        result_types=[out_type, out_type],
+        operands=[k1, k2, x1, x2],
+    ).results
+
+
 def _logistic_lowering(ctx, x, *, accuracy=None):
     """MPS lowering for logistic_p: emit a native stablehlo.logistic op.
 
@@ -1167,6 +1195,25 @@ def register_fused_ops():
     # logistic_p decomposes to 1/(1+exp(-x)) upstream; on MPS keep it as a
     # single stablehlo.logistic that dispatches to mlx::core::sigmoid.
     mlir.register_lowering(lax_lax.logistic_p, _logistic_lowering, platform="mps")
+
+    # threefry2x32: JAX inlines the PRNG round schedule as ~140 elementwise ops
+    # (no mps-platform lowering exists, unlike CUDA's cu_threefry2x32 custom
+    # call). Route it to a fused Metal kernel so jax.random inside a loop body
+    # stays on the counted-loop fast path (issue #196). prng is private jax
+    # internals; if the import ever breaks, fall back to the generic inline
+    # expansion — correct, just slower.
+    try:
+        from jax._src import prng
+
+        mlir.register_lowering(
+            prng.threefry2x32_p, _threefry2x32_lowering, platform="mps"
+        )
+    except Exception as e:  # pragma: no cover - defensive against jax internals
+        warnings.warn(
+            f"jax-mps: could not register fused threefry2x32 lowering ({e}); "
+            "jax.random will use the slower default expansion.",
+            stacklevel=2,
+        )
 
     # Fallback lowerings for non-MPS platforms (CPU, GPU).
     mlir.register_lowering(

--- a/src/pjrt_plugin/ops/control_flow.cc
+++ b/src/pjrt_plugin/ops/control_flow.cc
@@ -1633,25 +1633,30 @@ bool HandleCustomCall(mlir::Operation* op, ValueMap& values, std::vector<mlx::co
             return false;
         const mlx::core::Shape& outShape = *shapeOpt;
 
+        // Product of the output dims. The flat length and 1-D grid extent below
+        // are int32, so reject anything larger than 2^31-1 (a >2^31-element RNG
+        // draw is ~8+ GiB and not addressable by the Metal dispatch anyway).
+        // Check inside the loop: each MLX dim is int32, so bailing the instant
+        // the running product exceeds int32 max keeps `total` itself from
+        // overflowing int64 and slipping past the bound (int32max*int32max fits
+        // int64). A zero dim yields total 0 (handled below), never a spurious
+        // reject, since a single dim can never exceed int32 max on its own.
         int64_t total = 1;
-        for (auto d : outShape)
+        for (auto d : outShape) {
             total *= d;
+            if (total > std::numeric_limits<int32_t>::max()) {
+                MPS_LOG_ERROR(
+                    "mps.threefry2x32: output element count exceeds the "
+                    "maximum addressable by the Metal dispatch (2^31-1)\n");
+                return false;
+            }
+        }
         // Zero-sized output: nothing to hash, and a zero-thread dispatch is
         // meaningless. Emit correctly-shaped empty arrays.
         if (total == 0) {
             values.emplace(ToKey(op->getResult(0)), mlx::core::zeros(outShape, mlx::core::uint32));
             values.emplace(ToKey(op->getResult(1)), mlx::core::zeros(outShape, mlx::core::uint32));
             return true;
-        }
-        // The flat length and 1-D grid extent are int32; a larger element count
-        // would silently truncate. Fail loudly instead (a >2^31-element RNG draw
-        // is ~8+ GiB and not something the Metal dispatch can address anyway).
-        if (total > std::numeric_limits<int32_t>::max()) {
-            MPS_LOG_ERROR(
-                "mps.threefry2x32: output element count %lld exceeds the "
-                "maximum addressable by the Metal dispatch (2^31-1)\n",
-                static_cast<long long>(total));
-            return false;
         }
 
         // Broadcast every operand to the output shape so the kernel is a flat

--- a/src/pjrt_plugin/ops/control_flow.cc
+++ b/src/pjrt_plugin/ops/control_flow.cc
@@ -1316,6 +1316,103 @@ bool HandleCall(mlir::Operation* op, ValueMap& values, std::vector<mlx::core::ar
     return true;
 }
 
+// Evaluate JAX's threefry2x32 PRNG primitive as a single fused Metal kernel.
+//
+// threefry2x32-20 is pure integer arithmetic (add / rotate / xor) with the
+// standard Threefish rotation schedule {13,15,26,6}/{17,29,16,24}, parity
+// constant 0x1BD11BDA, and a key injection after every four rounds. This is
+// byte-for-byte the same schedule JAX's CPU lowering runs (see
+// jax/_src/prng.py `_threefry2x32_lowering`), so the outputs are bit-exact with
+// the CPU backend by construction — which the test harness relies on (it
+// compares MPS vs CPU integer outputs exactly). Do NOT swap in MLX's own RNG:
+// it uses a modified splittable variant that would not reproduce user seeds.
+//
+// Without this kernel, jax.random inlines threefry as ~140 tiny elementwise
+// StableHLO ops per key op; inside a compiled loop body every surviving MLX
+// node costs ~1.5us of dispatch, so a single random.split in a fori_loop body
+// ran ~30x slower than the arithmetic-only body (jax-mps#196). One kernel call
+// removes that per-node cost.
+//
+// Inputs (all uint32, broadcast to the output shape here): key0, key1, count0,
+// count1. Outputs: out0, out1 (uint32, output shape).
+std::vector<mlx::core::array> Threefry2x32Kernel(const mlx::core::array& k0,
+                                                 const mlx::core::array& k1,
+                                                 const mlx::core::array& x0,
+                                                 const mlx::core::array& x1,
+                                                 const mlx::core::Shape& outShape, int64_t total) {
+    static const char* kHeader = R"(
+inline uint32_t tfry_rotl(uint32_t x, uint32_t n) {
+    return (x << n) | (x >> (32u - n));
+}
+)";
+    // Body of the [[kernel]]; MLX declares key0/key1/count0/count1 as inputs,
+    // out0/out1 as outputs, and provides thread_position_in_grid. Inputs are
+    // row-contiguous (ensure_row_contiguous), so a flat 1-D index suffices.
+    static const char* kSource = R"(
+    uint idx = thread_position_in_grid.x;
+    uint32_t ks0 = key0[idx];
+    uint32_t ks1 = key1[idx];
+    uint32_t ks2 = ks0 ^ ks1 ^ 0x1BD11BDAu;
+    uint32_t X0 = count0[idx] + ks0;
+    uint32_t X1 = count1[idx] + ks1;
+    // block 0 — rotations {13,15,26,6}, inject (ks1, ks2 + 1)
+    X0 += X1; X1 = X0 ^ tfry_rotl(X1, 13u);
+    X0 += X1; X1 = X0 ^ tfry_rotl(X1, 15u);
+    X0 += X1; X1 = X0 ^ tfry_rotl(X1, 26u);
+    X0 += X1; X1 = X0 ^ tfry_rotl(X1, 6u);
+    X0 += ks1; X1 += ks2 + 1u;
+    // block 1 — rotations {17,29,16,24}, inject (ks2, ks0 + 2)
+    X0 += X1; X1 = X0 ^ tfry_rotl(X1, 17u);
+    X0 += X1; X1 = X0 ^ tfry_rotl(X1, 29u);
+    X0 += X1; X1 = X0 ^ tfry_rotl(X1, 16u);
+    X0 += X1; X1 = X0 ^ tfry_rotl(X1, 24u);
+    X0 += ks2; X1 += ks0 + 2u;
+    // block 2 — rotations {13,15,26,6}, inject (ks0, ks1 + 3)
+    X0 += X1; X1 = X0 ^ tfry_rotl(X1, 13u);
+    X0 += X1; X1 = X0 ^ tfry_rotl(X1, 15u);
+    X0 += X1; X1 = X0 ^ tfry_rotl(X1, 26u);
+    X0 += X1; X1 = X0 ^ tfry_rotl(X1, 6u);
+    X0 += ks0; X1 += ks1 + 3u;
+    // block 3 — rotations {17,29,16,24}, inject (ks1, ks2 + 4)
+    X0 += X1; X1 = X0 ^ tfry_rotl(X1, 17u);
+    X0 += X1; X1 = X0 ^ tfry_rotl(X1, 29u);
+    X0 += X1; X1 = X0 ^ tfry_rotl(X1, 16u);
+    X0 += X1; X1 = X0 ^ tfry_rotl(X1, 24u);
+    X0 += ks1; X1 += ks2 + 4u;
+    // block 4 — rotations {13,15,26,6}, inject (ks2, ks0 + 5)
+    X0 += X1; X1 = X0 ^ tfry_rotl(X1, 13u);
+    X0 += X1; X1 = X0 ^ tfry_rotl(X1, 15u);
+    X0 += X1; X1 = X0 ^ tfry_rotl(X1, 26u);
+    X0 += X1; X1 = X0 ^ tfry_rotl(X1, 6u);
+    X0 += ks2; X1 += ks0 + 5u;
+    out0[idx] = X0;
+    out1[idx] = X1;
+)";
+    // Building the CustomKernelFunction only assembles a std::function; the
+    // Metal library is compiled lazily and cached by MLX keyed on the kernel
+    // name, so a function-local static is safe and avoids re-wrapping per call.
+    static const mlx::core::fast::CustomKernelFunction kernel = mlx::core::fast::metal_kernel(
+        "threefry2x32", /*input_names=*/{"key0", "key1", "count0", "count1"},
+        /*output_names=*/{"out0", "out1"}, kSource, kHeader,
+        /*ensure_row_contiguous=*/true);
+
+    // Flatten to 1-D before dispatch: MLX declares rank-0 kernel inputs as
+    // scalar references (not pointers), so `count0[idx]` would not compile for
+    // a scalar output shape. A single flat axis also matches the 1-D grid.
+    mlx::core::Shape flat{static_cast<int32_t>(total)};
+    int threads = static_cast<int>(std::min<int64_t>(total, 256));
+    auto outs = kernel({mlx::core::reshape(k0, flat), mlx::core::reshape(k1, flat),
+                        mlx::core::reshape(x0, flat), mlx::core::reshape(x1, flat)},
+                       /*output_shapes=*/{flat, flat},
+                       /*output_dtypes=*/{mlx::core::uint32, mlx::core::uint32},
+                       /*grid=*/{static_cast<int>(total), 1, 1},
+                       /*threadgroup=*/{threads, 1, 1}, /*template_args=*/{},
+                       /*init_value=*/std::nullopt, /*verbose=*/false, /*s=*/{});
+    outs[0] = mlx::core::reshape(outs[0], outShape);
+    outs[1] = mlx::core::reshape(outs[1], outShape);
+    return outs;
+}
+
 // Handler for stablehlo.custom_call
 bool HandleCustomCall(mlir::Operation* op, ValueMap& values, std::vector<mlx::core::array>& outputs,
                       ExecContext& ctx) {
@@ -1512,6 +1609,49 @@ bool HandleCustomCall(mlir::Operation* op, ValueMap& values, std::vector<mlx::co
         auto out = mlx::core::quantized_matmul(*x, *packed, *scales, *biases, transpose, group_size,
                                                bits, "affine");
         values.emplace(ToKey(op->getResult(0)), std::move(out));
+        return true;
+    }
+
+    // Handle mps.threefry2x32 — JAX's threefry2x32 PRNG primitive as one fused
+    // Metal kernel (see Threefry2x32Kernel above and jax-mps#196). Inputs
+    // key0, key1, count0, count1 are uint32 and broadcastable to the (shared)
+    // output shape; outputs out0, out1 have that shape.
+    if (callTargetName == "mps.threefry2x32") {
+        if (op->getNumOperands() != 4 || op->getNumResults() != 2) {
+            MPS_LOG_ERROR("mps.threefry2x32: expected 4 inputs and 2 outputs\n");
+            return false;
+        }
+        auto* k0 = RequireValue(values, op->getOperand(0), "mps.threefry2x32");
+        auto* k1 = RequireValue(values, op->getOperand(1), "mps.threefry2x32");
+        auto* x0 = RequireValue(values, op->getOperand(2), "mps.threefry2x32");
+        auto* x1 = RequireValue(values, op->getOperand(3), "mps.threefry2x32");
+        if (!k0 || !k1 || !x0 || !x1)
+            return false;
+
+        auto shapeOpt = GetResultShape(op, "mps.threefry2x32");
+        if (!shapeOpt)
+            return false;
+        const mlx::core::Shape& outShape = *shapeOpt;
+
+        int64_t total = 1;
+        for (auto d : outShape)
+            total *= d;
+        // Zero-sized output: nothing to hash, and a zero-thread dispatch is
+        // meaningless. Emit correctly-shaped empty arrays.
+        if (total == 0) {
+            values.emplace(ToKey(op->getResult(0)), mlx::core::zeros(outShape, mlx::core::uint32));
+            values.emplace(ToKey(op->getResult(1)), mlx::core::zeros(outShape, mlx::core::uint32));
+            return true;
+        }
+
+        // Broadcast every operand to the output shape so the kernel is a flat
+        // elementwise map (keys are typically scalars, counts the full shape).
+        auto outs = Threefry2x32Kernel(mlx::core::broadcast_to(*k0, outShape),
+                                       mlx::core::broadcast_to(*k1, outShape),
+                                       mlx::core::broadcast_to(*x0, outShape),
+                                       mlx::core::broadcast_to(*x1, outShape), outShape, total);
+        values.emplace(ToKey(op->getResult(0)), std::move(outs[0]));
+        values.emplace(ToKey(op->getResult(1)), std::move(outs[1]));
         return true;
     }
 

--- a/src/pjrt_plugin/ops/control_flow.cc
+++ b/src/pjrt_plugin/ops/control_flow.cc
@@ -1643,6 +1643,16 @@ bool HandleCustomCall(mlir::Operation* op, ValueMap& values, std::vector<mlx::co
             values.emplace(ToKey(op->getResult(1)), mlx::core::zeros(outShape, mlx::core::uint32));
             return true;
         }
+        // The flat length and 1-D grid extent are int32; a larger element count
+        // would silently truncate. Fail loudly instead (a >2^31-element RNG draw
+        // is ~8+ GiB and not something the Metal dispatch can address anyway).
+        if (total > std::numeric_limits<int32_t>::max()) {
+            MPS_LOG_ERROR(
+                "mps.threefry2x32: output element count %lld exceeds the "
+                "maximum addressable by the Metal dispatch (2^31-1)\n",
+                static_cast<long long>(total));
+            return false;
+        }
 
         // Broadcast every operand to the output shape so the kernel is a flat
         // elementwise map (keys are typically scalars, counts the full shape).

--- a/tests/configs/random.py
+++ b/tests/configs/random.py
@@ -31,6 +31,19 @@ def make_random_op_configs():
                 OperationTestConfig(
                     random.split, random.key(18), 5, static_argnums=(1,)
                 ),
+                # Exercises threefry2x32 directly (issue #196): integer outputs
+                # are compared MPS-vs-CPU exactly, so these pin bit-exactness of
+                # the fused Metal kernel to JAX's CPU backend.
+                OperationTestConfig(
+                    random.bits, random.key(19), shape, static_argnums=(1,)
+                ),
+                OperationTestConfig(
+                    lambda key, shape: random.randint(key, shape, 0, 1_000_000),
+                    random.key(20),
+                    shape,
+                    static_argnums=(1,),
+                    name="randint",
+                ),
             ]
         # Bug: indexing into split result differs on MPS vs CPU in eager mode.
         # JIT compiles around the bug; only eager exposes it.

--- a/tests/configs/random.py
+++ b/tests/configs/random.py
@@ -1,55 +1,97 @@
+from jax import numpy as jnp
 from jax import random
 
 from .util import MPS_DEVICE, OperationTestConfig
 
 
-def make_random_op_configs():
-    with OperationTestConfig.module_name("random"):
-        for shape in [(), (3,), (4, 8)]:
-            yield from [
-                OperationTestConfig(
-                    random.normal, random.key(17), shape, static_argnums=(1,)
-                ),
-                OperationTestConfig(
-                    random.truncated_normal,
-                    random.key(17),
-                    -0.1,
-                    0.2,
-                    shape,
-                    static_argnums=(3,),
-                ),
-                OperationTestConfig(
-                    random.uniform,
-                    random.key(17),
-                    (3,),
-                    None,
-                    0.3,
-                    0.5,
-                    static_argnums=(1,),
-                ),
-                OperationTestConfig(random.split, random.key(18)),
-                OperationTestConfig(
-                    random.split, random.key(18), 5, static_argnums=(1,)
-                ),
-                # Exercises threefry2x32 directly (issue #196): integer outputs
-                # are compared MPS-vs-CPU exactly, so these pin bit-exactness of
-                # the fused Metal kernel to JAX's CPU backend.
-                OperationTestConfig(
-                    random.bits, random.key(19), shape, static_argnums=(1,)
-                ),
-                OperationTestConfig(
-                    lambda key, shape: random.randint(key, shape, 0, 1_000_000),
-                    random.key(20),
-                    shape,
-                    static_argnums=(1,),
-                    name="randint",
-                ),
-            ]
-        # Bug: indexing into split result differs on MPS vs CPU in eager mode.
-        # JIT compiles around the bug; only eager exposes it.
-        if MPS_DEVICE is not None:
-            yield OperationTestConfig(
-                lambda key: random.split(key)[0],
-                random.key(42),
-                name="split_index",
-            )
+def make_random_op_configs(partitionable=None):
+    """Random-op configs, optionally pinned to a jax_threefry_partitionable setting.
+
+    Pass ``partitionable=True``/``False`` to run every config under that flag
+    (applied at evaluation time via ``config_overrides``, since the flag is read
+    at lowering time). The two settings select different count-packing lowerings
+    around the same threefry2x32 primitive (issue #196), so calling this twice
+    checks MPS-vs-CPU equivalence under both. ``None`` keeps the ambient default.
+    """
+    overrides = (
+        None if partitionable is None else {"jax_threefry_partitionable": partitionable}
+    )
+    suffix = (
+        ""
+        if partitionable is None
+        else ("_partitionable" if partitionable else "_original")
+    )
+
+    def _build():
+        with OperationTestConfig.module_name("random"):
+            # scalar / small-odd / even-2d / large-odd — the last exercises the
+            # odd/even split boundary in the count-packing layout (issue #196).
+            for shape in [(), (3,), (4, 8), (257,)]:
+                yield from [
+                    OperationTestConfig(
+                        random.normal, random.key(17), shape, static_argnums=(1,)
+                    ),
+                    OperationTestConfig(
+                        random.truncated_normal,
+                        random.key(17),
+                        -0.1,
+                        0.2,
+                        shape,
+                        static_argnums=(3,),
+                    ),
+                    OperationTestConfig(
+                        random.uniform,
+                        random.key(17),
+                        (3,),
+                        None,
+                        0.3,
+                        0.5,
+                        static_argnums=(1,),
+                    ),
+                    OperationTestConfig(random.split, random.key(18)),
+                    OperationTestConfig(
+                        random.split, random.key(18), 5, static_argnums=(1,)
+                    ),
+                    # Integer outputs are compared MPS-vs-CPU exactly, so these
+                    # pin bit-exactness of the fused threefry Metal kernel to
+                    # JAX's CPU backend (issue #196). uint8/uint16 exercise the
+                    # sub-word packing paths; uint32 the full-word path.
+                    OperationTestConfig(
+                        lambda key, shape: random.bits(key, shape, dtype=jnp.uint8),
+                        random.key(19),
+                        shape,
+                        static_argnums=(1,),
+                        name="bits_uint8",
+                    ),
+                    OperationTestConfig(
+                        lambda key, shape: random.bits(key, shape, dtype=jnp.uint16),
+                        random.key(19),
+                        shape,
+                        static_argnums=(1,),
+                        name="bits_uint16",
+                    ),
+                    OperationTestConfig(
+                        random.bits, random.key(19), shape, static_argnums=(1,)
+                    ),
+                    OperationTestConfig(
+                        lambda key, shape: random.randint(key, shape, 0, 1_000_000),
+                        random.key(20),
+                        shape,
+                        static_argnums=(1,),
+                        name="randint",
+                    ),
+                ]
+            # Bug: indexing into split result differs on MPS vs CPU in eager mode.
+            # JIT compiles around the bug; only eager exposes it.
+            if MPS_DEVICE is not None:
+                yield OperationTestConfig(
+                    lambda key: random.split(key)[0],
+                    random.key(42),
+                    name="split_index",
+                )
+
+    for config in _build():
+        if overrides is not None:
+            config.config_overrides = overrides
+            config.name = f"{config.name}{suffix}"
+        yield config

--- a/tests/configs/random.py
+++ b/tests/configs/random.py
@@ -42,7 +42,7 @@ def make_random_op_configs(partitionable=None):
                     OperationTestConfig(
                         random.uniform,
                         random.key(17),
-                        (3,),
+                        shape,
                         None,
                         0.3,
                         0.5,

--- a/tests/configs/util.py
+++ b/tests/configs/util.py
@@ -95,6 +95,7 @@ class OperationTestConfig:
         grad_xfail_strict: bool = True,
         name: str | None = None,
         seed: int = 42,
+        config_overrides: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
         self.func = func
@@ -102,6 +103,10 @@ class OperationTestConfig:
         self.static_argnums = static_argnums
         self.grad_transform = grad_transform or jax.grad
         self.grad_xfail = grad_xfail
+        # jax.config flags to apply (and restore) around evaluation. Needed for
+        # flags read at lowering time, e.g. jax_threefry_partitionable, which a
+        # config-construction-time toggle would not capture.
+        self.config_overrides = config_overrides or {}
         # When False, the grad xfail is non-strict: the test may pass (xpass) or
         # fail (xfail) without erroring. Use for intermittent/flaky failures.
         self.grad_xfail_strict = grad_xfail_strict
@@ -163,8 +168,27 @@ class OperationTestConfig:
                 differentiable_argnums.append(argnum)
         return tuple(differentiable_argnums)
 
+    @contextmanager
+    def _apply_config_overrides(self):
+        """Apply self.config_overrides as jax.config flags, restoring after."""
+        if not self.config_overrides:
+            yield
+            return
+        previous = {k: getattr(jax.config, k) for k in self.config_overrides}
+        for k, v in self.config_overrides.items():
+            jax.config.update(k, v)
+        try:
+            yield
+        finally:
+            for k, v in previous.items():
+                jax.config.update(k, v)
+
     def evaluate_value(self, jit: bool):
         """Evaluate the output of the operation."""
+        with self._apply_config_overrides():
+            return self._evaluate_value(jit)
+
+    def _evaluate_value(self, jit: bool):
         key = random.key(self.seed)
         args_key, kwargs_key = random.split(key)
         args = self.get_args(args_key)
@@ -185,6 +209,10 @@ class OperationTestConfig:
     def evaluate_grad(self, argnum: int, jit: bool) -> tuple[jnp.ndarray]:
         """Evaluate the gradient of the operation. If the operation returns a tuple of
         values, gradients are evaluated for each element."""
+        with self._apply_config_overrides():
+            return self._evaluate_grad(argnum, jit)
+
+    def _evaluate_grad(self, argnum: int, jit: bool) -> tuple[jnp.ndarray]:
         key = random.key(self.seed)
         args_key, kwargs_key = random.split(key)
         args = self.get_args(args_key)

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -354,3 +354,48 @@ def test_rng_bit_generator() -> None:
         new_state2, output2 = lax.rng_bit_generator(state, (8,))
         assert jnp.array_equal(output2, output)
         assert jnp.array_equal(new_state2, new_state)
+
+
+def test_threefry2x32_lowers_to_custom_call() -> None:
+    """Regression: jax.random must lower to our fused @mps.threefry2x32 custom
+    call (issue #196) rather than JAX's ~140-op inline PRNG expansion. A future
+    JAX change that drops the mps-platform lowering would make this fail."""
+    if TEST_MODE == "cpu":
+        pytest.skip("MPS-specific test skipped in CPU-only mode")
+
+    device = jax.devices("mps")[0]
+    with jax.default_device(device):
+        key = random.key(0)
+        ir_text = str(
+            jax.jit(lambda k: random.bits(k, shape=(16,))).lower(key).as_text()
+        )
+    assert "@mps.threefry2x32" in ir_text, (
+        f"Expected `@mps.threefry2x32` in lowered IR; got:\n{ir_text}"
+    )
+
+
+@pytest.mark.parametrize("partitionable", [True, False])
+def test_threefry_partitionable(partitionable: bool) -> None:
+    """threefry2x32 is bit-exact with the CPU backend under both settings of
+    jax_threefry_partitionable, which selects different count-packing lowerings
+    around the same primitive (issue #196)."""
+    if TEST_MODE != "compare":
+        pytest.skip("Requires both CPU and MPS to compare")
+
+    def fn(key):
+        k1, k2 = random.split(key)
+        return random.randint(k1, (257,), 0, 2**31 - 1), random.bits(k2, shape=(257,))
+
+    prev = jax.config.jax_threefry_partitionable  # pyright: ignore[reportAttributeAccessIssue]
+    jax.config.update("jax_threefry_partitionable", partitionable)
+    try:
+        results = []
+        for platform in ("cpu", "mps"):
+            with jax.default_device(jax.devices(platform)[0]):
+                results.append(jax.jit(fn)(random.key(21)))
+        for cpu_arr, mps_arr in zip(*results):
+            numpy.testing.assert_array_equal(
+                numpy.asarray(cpu_arr), numpy.asarray(mps_arr)
+            )
+    finally:
+        jax.config.update("jax_threefry_partitionable", prev)

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -371,7 +371,9 @@ def test_threefry2x32_lowers_to_custom_call() -> None:
     with jax.default_device(device):
         key = random.key(0)
         ir_text = str(
-            jax.jit(lambda k: random.bits(k, shape=(16,))).lower(key).as_text()
+            jax.jit(lambda k: random.bits(k, shape=(16,)))
+            .lower(key)
+            .compiler_ir(dialect="stablehlo")
         )
     assert "@mps.threefry2x32" in ir_text, (
         f"Expected `@mps.threefry2x32` in lowered IR; got:\n{ir_text}"

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -374,28 +374,51 @@ def test_threefry2x32_lowers_to_custom_call() -> None:
     )
 
 
-@pytest.mark.parametrize("partitionable", [True, False])
-def test_threefry_partitionable(partitionable: bool) -> None:
-    """threefry2x32 is bit-exact with the CPU backend under both settings of
-    jax_threefry_partitionable, which selects different count-packing lowerings
-    around the same primitive (issue #196)."""
+@pytest.mark.parametrize("partitionable", [False, True])
+@pytest.mark.parametrize(
+    "shape",
+    [(), (4,), (7,), (3, 5), (257,)],
+    ids=["scalar", "even", "odd", "2d", "big"],
+)
+def test_threefry_bit_exact(partitionable: bool, shape) -> None:
+    """threefry RNG must be bit-exact with the CPU backend across shapes
+    (scalar, even, odd, multi-dim, and a large odd size that exercises the
+    odd/even split boundary), bit widths (uint8/16/32), and both settings of
+    ``jax_threefry_partitionable`` (which select different count-packing
+    lowerings around the same primitive — issue #196).
+
+    This is the regression net for any future kernel that absorbs the packing
+    wrapper (issue #210): today it passes because JAX still owns the layout, so
+    it will light up the moment a layout-owning kernel gets a variant wrong.
+    64-bit (uint64) is not covered here — it needs JAX_ENABLE_X64 (otherwise it
+    truncates to uint32); the #210 64-bit kernel should add an x64 test.
+    """
     if TEST_MODE != "compare":
         pytest.skip("Requires both CPU and MPS to compare")
 
     def fn(key):
-        k1, k2 = random.split(key)
-        return random.randint(k1, (257,), 0, 2**31 - 1), random.bits(k2, shape=(257,))
+        outs = {
+            # split exercises the key-derivation path (shape-independent, but
+            # its own count layout differs between the two flag settings).
+            "split": random.key_data(random.split(key, 3)),
+            "randint": random.randint(key, shape, 0, 2**31 - 1),
+        }
+        for dt in (jnp.uint8, jnp.uint16, jnp.uint32):
+            outs[f"bits_{dt.__name__}"] = random.bits(key, shape, dtype=dt)
+        return outs
 
     prev = jax.config.jax_threefry_partitionable  # pyright: ignore[reportAttributeAccessIssue]
     jax.config.update("jax_threefry_partitionable", partitionable)
     try:
-        results = []
+        results = {}
         for platform in ("cpu", "mps"):
             with jax.default_device(jax.devices(platform)[0]):
-                results.append(jax.jit(fn)(random.key(21)))
-        for cpu_arr, mps_arr in zip(*results):
+                results[platform] = jax.jit(fn)(random.key(21))
+        for name in results["cpu"]:
             numpy.testing.assert_array_equal(
-                numpy.asarray(cpu_arr), numpy.asarray(mps_arr)
+                numpy.asarray(results["cpu"][name]),
+                numpy.asarray(results["mps"][name]),
+                err_msg=f"{name} mismatch (partitionable={partitionable}, shape={shape})",
             )
     finally:
         jax.config.update("jax_threefry_partitionable", prev)

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -57,7 +57,11 @@ OPERATION_TEST_CONFIGS = [
     *make_misc_op_configs(),
     *make_numpyro_op_configs(),
     *make_quantized_op_configs(),
-    *make_random_op_configs(),
+    # Run every random config under both jax_threefry_partitionable settings —
+    # they select different count-packing lowerings around the same threefry2x32
+    # primitive, so both must stay MPS-vs-CPU equivalent (issue #196).
+    *make_random_op_configs(partitionable=False),
+    *make_random_op_configs(partitionable=True),
     *make_reduction_op_configs(),
     *make_shape_op_configs(),
     *make_slice_op_configs(),
@@ -372,53 +376,3 @@ def test_threefry2x32_lowers_to_custom_call() -> None:
     assert "@mps.threefry2x32" in ir_text, (
         f"Expected `@mps.threefry2x32` in lowered IR; got:\n{ir_text}"
     )
-
-
-@pytest.mark.parametrize("partitionable", [False, True])
-@pytest.mark.parametrize(
-    "shape",
-    [(), (4,), (7,), (3, 5), (257,)],
-    ids=["scalar", "even", "odd", "2d", "big"],
-)
-def test_threefry_bit_exact(partitionable: bool, shape) -> None:
-    """threefry RNG must be bit-exact with the CPU backend across shapes
-    (scalar, even, odd, multi-dim, and a large odd size that exercises the
-    odd/even split boundary), bit widths (uint8/16/32), and both settings of
-    ``jax_threefry_partitionable`` (which select different count-packing
-    lowerings around the same primitive — issue #196).
-
-    This is the regression net for any future kernel that absorbs the packing
-    wrapper (issue #210): today it passes because JAX still owns the layout, so
-    it will light up the moment a layout-owning kernel gets a variant wrong.
-    64-bit (uint64) is not covered here — it needs JAX_ENABLE_X64 (otherwise it
-    truncates to uint32); the #210 64-bit kernel should add an x64 test.
-    """
-    if TEST_MODE != "compare":
-        pytest.skip("Requires both CPU and MPS to compare")
-
-    def fn(key):
-        outs = {
-            # split exercises the key-derivation path (shape-independent, but
-            # its own count layout differs between the two flag settings).
-            "split": random.key_data(random.split(key, 3)),
-            "randint": random.randint(key, shape, 0, 2**31 - 1),
-        }
-        for dt in (jnp.uint8, jnp.uint16, jnp.uint32):
-            outs[f"bits_{dt.__name__}"] = random.bits(key, shape, dtype=dt)
-        return outs
-
-    prev = jax.config.jax_threefry_partitionable  # pyright: ignore[reportAttributeAccessIssue]
-    jax.config.update("jax_threefry_partitionable", partitionable)
-    try:
-        results = {}
-        for platform in ("cpu", "mps"):
-            with jax.default_device(jax.devices(platform)[0]):
-                results[platform] = jax.jit(fn)(random.key(21))
-        for name in results["cpu"]:
-            numpy.testing.assert_array_equal(
-                numpy.asarray(results["cpu"][name]),
-                numpy.asarray(results["mps"][name]),
-                err_msg=f"{name} mismatch (partitionable={partitionable}, shape={shape})",
-            )
-    finally:
-        jax.config.update("jax_threefry_partitionable", prev)


### PR DESCRIPTION
## Summary

Closes the main slowdown in #196: `jax.random` inside a `lax.fori_loop` / `lax.scan` body.

`jax.random` inlines the threefry2x32 PRNG round schedule as **~140 tiny elementwise ops** per key op. Inside a compiled loop body every surviving MLX node costs ~1.5 µs of dispatch, so a single `random.split` in a `fori_loop` body ran ~30× slower than an arithmetic-only body (~190 vs ~6 µs/iter).

This registers an MPS-platform lowering for JAX's `threefry2x32_p` primitive that emits `custom_call @mps.threefry2x32`, dispatched to **one fused Metal kernel** running the standard threefry2x32-20 schedule (via `mlx::core::fast::metal_kernel`) — mirroring how XLA's CUDA backend uses `cu_threefry2x32`.

## Result

`split`-in-`fori_loop` (MWE from the issue): **~190 → ~20 µs/iter** (arithmetic baseline ~7). The primitive now lowers to a single op; the residual is JAX's counter-packing wrapper around the primitive (tracked as a follow-up).

## Bit-exactness

The kernel uses the exact same rotation schedule `{13,15,26,6}`/`{17,29,16,24}`, parity constant `0x1BD11BDA`, and key-injection cadence as JAX's CPU lowering, so outputs are **bit-exact with the CPU backend by construction**. The test harness compares MPS-vs-CPU integer RNG outputs exactly, so this is enforced.

## Details

- Python: `_threefry2x32_lowering` in `src/jax_plugins/mps/ops.py`, registered for `platform="mps"`, wrapped in `try/except` so a break in private JAX internals falls back to the default (correct, slower) inline expansion.
- C++: `Threefry2x32Kernel` helper + `@mps.threefry2x32` branch in `HandleCustomCall`. Operands are broadcast to the result shape; MLX declares rank-0 kernel inputs as scalar *references*, so operands are flattened to 1-D before dispatch and outputs reshaped back. Zero-sized outputs short-circuit to zeros.
- Works under both `jax_threefry_partitionable` settings (same primitive underneath).

## Tests

- `tests/configs/random.py`: `make_random_op_configs(partitionable=)` is now called for both settings, so every random config (`normal`/`uniform`/`truncated_normal`/`split`/`bits` at uint8/16/32/`randint`) runs MPS-vs-CPU under both `jax_threefry_partitionable` values, across shapes `()`/`(3,)`/`(4,8)`/`(257,)` (integer outputs compared **exactly**, in both jit and eager). `OperationTestConfig` gained a generic `config_overrides` hook to apply the flag at lowering time.
- `tests/test_ops.py`: `test_threefry2x32_lowers_to_custom_call` guards against silent regression of the lowering.
- Full suite green via pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
