### PR TITLE
(stablehlo.all_reduce): identity behaviour on single device all_reduce

### DIFF
--- a/src/pjrt_plugin/ops/reduction.cc
+++ b/src/pjrt_plugin/ops/reduction.cc
@@ -646,7 +646,8 @@ bool HandleAllReduce(mlir::Operation* op, ValueMap& values, std::vector<mlx::cor
     }
 
     if (op->getNumOperands() != op->getNumResults()) {
-        MPS_LOG_ERROR("stablehlo.all_reduce: operand/result count mismatch\n");
+        ctx.error_message = "stablehlo.all_reduce: operand/result count mismatch";
+        MPS_LOG_ERROR("%s\n", ctx.error_message.c_str());
         return false;
     }
 

--- a/src/pjrt_plugin/ops/reduction.cc
+++ b/src/pjrt_plugin/ops/reduction.cc
@@ -625,12 +625,47 @@ bool HandleSelectAndScatter(mlir::Operation* op, ValueMap& values,
     return true;
 }
 
+// Handler for stablehlo.all_reduce.
+//
+// This is a single-device/debug fallback: bypass the collective and forward each
+// operand as the corresponding result. Multi-device collectives must fail
+// loudly; treating them as identity would silently produce wrong values.
+bool HandleAllReduce(mlir::Operation* op, ValueMap& values, std::vector<mlx::core::array>& outputs,
+                     ExecContext& ctx) {
+    auto replicaGroups = op->getAttrOfType<mlir::DenseIntElementsAttr>("replica_groups");
+    if (replicaGroups && !replicaGroups.empty()) {
+        auto groupType = mlir::dyn_cast<mlir::RankedTensorType>(replicaGroups.getType());
+        bool isMultiDevice =
+            (!groupType || groupType.getRank() < 2) ? replicaGroups.getNumElements() > 1
+                                                    : groupType.getShape().back() > 1;
+        if (isMultiDevice) {
+            ctx.error_message = "stablehlo.all_reduce: multi-device all_reduce is not supported";
+            MPS_LOG_ERROR("%s\n", ctx.error_message.c_str());
+            return false;
+        }
+    }
+
+    if (op->getNumOperands() != op->getNumResults()) {
+        MPS_LOG_ERROR("stablehlo.all_reduce: operand/result count mismatch\n");
+        return false;
+    }
+
+    for (unsigned i = 0; i < op->getNumOperands(); ++i) {
+        auto* input = RequireValue(values, op->getOperand(i), "stablehlo.all_reduce");
+        if (!input)
+            return false;
+        values.emplace(ToKey(op->getResult(i)), *input);
+    }
+    return true;
+}
+
 }  // namespace
 
 void RegisterReductionHandlers(std::unordered_map<std::string, OpHandler>& handlers) {
     handlers.insert({"stablehlo.reduce", HandleReduce});
     handlers.insert({"stablehlo.reduce_window", HandleReduceWindow});
     handlers.insert({"stablehlo.select_and_scatter", HandleSelectAndScatter});
+    handlers.insert({"stablehlo.all_reduce", HandleAllReduce});
 }
 
 }  // namespace jax_mps

--- a/src/pjrt_plugin/ops/reduction.cc
+++ b/src/pjrt_plugin/ops/reduction.cc
@@ -635,9 +635,9 @@ bool HandleAllReduce(mlir::Operation* op, ValueMap& values, std::vector<mlx::cor
     auto replicaGroups = op->getAttrOfType<mlir::DenseIntElementsAttr>("replica_groups");
     if (replicaGroups && !replicaGroups.empty()) {
         auto groupType = mlir::dyn_cast<mlir::RankedTensorType>(replicaGroups.getType());
-        bool isMultiDevice =
-            (!groupType || groupType.getRank() < 2) ? replicaGroups.getNumElements() > 1
-                                                    : groupType.getShape().back() > 1;
+        bool isMultiDevice = (!groupType || groupType.getRank() < 2)
+                                 ? replicaGroups.getNumElements() > 1
+                                 : groupType.getShape().back() > 1;
         if (isMultiDevice) {
             ctx.error_message = "stablehlo.all_reduce: multi-device all_reduce is not supported";
             MPS_LOG_ERROR("%s\n", ctx.error_message.c_str());

--- a/tests/configs/reduction.py
+++ b/tests/configs/reduction.py
@@ -1,7 +1,23 @@
+import jax
 from jax import lax, random
 from jax import numpy as jnp
 
 from .util import OperationTestConfig, complex_standard_normal
+
+
+def _all_reduce_pmean(x):
+    """Single-device pmean, lowering to stablehlo.all_reduce (issue #201).
+
+    pmap ignores jax.default_device, so pin it to the harness's current default
+    device; otherwise the collective always runs on the default (MPS) backend and
+    the CPU comparison pass fails its device-placement assertion.
+    """
+    # getattr: jax.config exposes jax_default_device at runtime but pyright's
+    # stubs don't declare it.
+    dev = getattr(jax.config, "jax_default_device", None) or jax.devices()[0]
+    return jax.pmap(
+        lambda y: lax.pmean(y, axis_name="i"), axis_name="i", devices=[dev]
+    )(x)
 
 
 def make_reduction_op_configs():
@@ -82,6 +98,17 @@ def make_reduction_op_configs():
             lambda x: lax.reduce_window(x, 0.0, lax.add, (), (), "valid"),
             lambda key: random.normal(key, ()),
             name="reduce_window_scalar",
+        )
+
+    # stablehlo.all_reduce: single-device identity fallback (issue #201). pmap
+    # over one device emits all_reduce with a 1x1 replica_groups; the handler
+    # forwards operand -> result. The pmean VJP is itself an all_reduce, so the
+    # default grad path exercises the handler on the backward pass too.
+    with OperationTestConfig.module_name("reduction-real"):
+        yield OperationTestConfig(
+            _all_reduce_pmean,
+            lambda key: random.normal(key, (1, 4)),
+            name="all_reduce-pmean-identity",
         )
 
     # Pooling operations (lower to stablehlo.reduce_window with pooling pattern).


### PR DESCRIPTION
Addresses #201.

This fallback is very handy when prototyping multi-device computations on a single Mac without changing code.

P.S.: Not sure if this deserves its own `collectives.cc`. Other than `all_reduce`, not all collectives have an identity-like behavior. In many cases they are undefined for single device.