### PR TITLE
(stablehlo.partition_id): add op handling and migrate to collectives.cc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,7 @@ set(PJRT_SOURCES
     src/pjrt_plugin/ops/slice.cc
     src/pjrt_plugin/ops/gather_scatter.cc
     src/pjrt_plugin/ops/reduction.cc
+    src/pjrt_plugin/ops/collectives.cc
     src/pjrt_plugin/ops/linalg.cc
     src/pjrt_plugin/ops/control_flow.cc
     src/pjrt_plugin/ops/sort_fft_complex.cc

--- a/scripts/_pytest_skip_unsupported_plugin.py
+++ b/scripts/_pytest_skip_unsupported_plugin.py
@@ -69,11 +69,15 @@ _UNSUPPORTED_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     # Collective ops require a multi-device mesh; MPS presents a single device.
     # Match the specific collective op names inside the "Unsupported operation(s)"
     # message so generic missing-handler failures stay visible.
+    #
+    # replica_id has no handler: current JAX lowers axis_index to partition_id
+    # (handled), leaving replica_id unreachable, so it stays skip-listed as a
+    # forward-looking guard in case a future lowering revives the replica path.
     (
         re.compile(
             r"Unsupported operation\(s\): stablehlo\."
             r"(all_gather|all_to_all|collective_permute|"
-            r"collective_broadcast|reduce_scatter)"
+            r"collective_broadcast|reduce_scatter|replica_id)"
         ),
         "collective ops require a multi-device mesh; MPS is single-device",
     ),

--- a/scripts/_pytest_skip_unsupported_plugin.py
+++ b/scripts/_pytest_skip_unsupported_plugin.py
@@ -72,8 +72,8 @@ _UNSUPPORTED_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (
         re.compile(
             r"Unsupported operation\(s\): stablehlo\."
-            r"(all_reduce|all_gather|all_to_all|collective_permute|"
-            r"collective_broadcast|reduce_scatter|partition_id|replica_id)"
+            r"(all_gather|all_to_all|collective_permute|"
+            r"collective_broadcast|reduce_scatter)"
         ),
         "collective ops require a multi-device mesh; MPS is single-device",
     ),

--- a/src/pjrt_plugin/mlx_executable.cc
+++ b/src/pjrt_plugin/mlx_executable.cc
@@ -573,6 +573,7 @@ const std::unordered_map<std::string, OpHandler>& GetOpHandlers() {
         RegisterSliceHandlers(h);
         RegisterGatherScatterHandlers(h);
         RegisterReductionHandlers(h);
+        RegisterCollectivesHandlers(h);
         RegisterLinalgHandlers(h);
         RegisterControlFlowHandlers(h);
         RegisterSortFftComplexHandlers(h);

--- a/src/pjrt_plugin/ops/collectives.cc
+++ b/src/pjrt_plugin/ops/collectives.cc
@@ -1,0 +1,87 @@
+// Collective op handlers.
+//
+// jax-mps does not support multi-device collectives. The handlers in this file
+// are single-device fallbacks for programs that still lower through collective
+// StableHLO ops with one local device/partition.
+
+#include <cstdint>
+
+#include "pjrt_plugin/ops/handler_utils.h"
+
+namespace jax_mps {
+
+namespace {
+
+// Handler for stablehlo.all_reduce.
+//
+// This is a single-device/debug fallback: bypass the collective and forward each
+// operand as the corresponding result. Multi-device collectives must fail
+// loudly; treating them as identity would silently produce wrong values.
+bool HandleAllReduce(mlir::Operation* op, ValueMap& values, std::vector<mlx::core::array>& outputs,
+                     ExecContext& ctx) {
+    auto replicaGroups = op->getAttrOfType<mlir::DenseIntElementsAttr>("replica_groups");
+    if (replicaGroups && !replicaGroups.empty()) {
+        auto groupType = mlir::dyn_cast<mlir::RankedTensorType>(replicaGroups.getType());
+        bool isMultiDevice = (!groupType || groupType.getRank() < 2)
+                                 ? replicaGroups.getNumElements() > 1
+                                 : groupType.getShape().back() > 1;
+        if (isMultiDevice) {
+            ctx.error_message = "stablehlo.all_reduce: multi-device all_reduce is not supported";
+            MPS_LOG_ERROR("%s\n", ctx.error_message.c_str());
+            return false;
+        }
+    }
+
+    if (op->getNumOperands() != op->getNumResults()) {
+        ctx.error_message = "stablehlo.all_reduce: operand/result count mismatch";
+        MPS_LOG_ERROR("%s\n", ctx.error_message.c_str());
+        return false;
+    }
+
+    for (unsigned i = 0; i < op->getNumOperands(); ++i) {
+        auto* input = RequireValue(values, op->getOperand(i), "stablehlo.all_reduce");
+        if (!input)
+            return false;
+        values.emplace(ToKey(op->getResult(i)), *input);
+    }
+    return true;
+}
+
+// Handler for stablehlo.partition_id.
+//
+// This is a single-process/single-partition fallback: returns partition id
+// zero so pmap axis_index lowerings work on one MPS device. Multi-partition
+// execution must fail loudly; returning zero there would silently produce wrong
+// values.
+bool HandlePartitionId(mlir::Operation* op, ValueMap& values, std::vector<mlx::core::array>& outputs,
+                       ExecContext& ctx) {
+    if (auto numPartitions = ctx.module->getAttrOfType<mlir::IntegerAttr>("mhlo.num_partitions")) {
+        if (numPartitions.getInt() != 1) {
+            ctx.error_message =
+                "stablehlo.partition_id: multi-partition execution is not supported";
+            MPS_LOG_ERROR("%s\n", ctx.error_message.c_str());
+            return false;
+        }
+    }
+
+    auto resultType = mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
+    if (!resultType || resultType.getRank() != 0) {
+        ctx.error_message = "stablehlo.partition_id: result must be a scalar tensor";
+        MPS_LOG_ERROR("%s\n", ctx.error_message.c_str());
+        return false;
+    }
+
+    auto dtype = MlirTypeToMlxDtype(resultType.getElementType());
+    values.emplace(ToKey(op->getResult(0)),
+                   mlx::core::astype(mlx::core::array(static_cast<uint32_t>(0)), dtype));
+    return true;
+}
+
+}  // namespace
+
+void RegisterCollectivesHandlers(std::unordered_map<std::string, OpHandler>& handlers) {
+    handlers.insert({"stablehlo.all_reduce", HandleAllReduce});
+    handlers.insert({"stablehlo.partition_id", HandlePartitionId});
+}
+
+}  // namespace jax_mps

--- a/src/pjrt_plugin/ops/collectives.cc
+++ b/src/pjrt_plugin/ops/collectives.cc
@@ -53,8 +53,8 @@ bool HandleAllReduce(mlir::Operation* op, ValueMap& values, std::vector<mlx::cor
 // zero so pmap axis_index lowerings work on one MPS device. Multi-partition
 // execution must fail loudly; returning zero there would silently produce wrong
 // values.
-bool HandlePartitionId(mlir::Operation* op, ValueMap& values, std::vector<mlx::core::array>& outputs,
-                       ExecContext& ctx) {
+bool HandlePartitionId(mlir::Operation* op, ValueMap& values,
+                       std::vector<mlx::core::array>& outputs, ExecContext& ctx) {
     if (auto numPartitions = ctx.module->getAttrOfType<mlir::IntegerAttr>("mhlo.num_partitions")) {
         if (numPartitions.getInt() != 1) {
             ctx.error_message =

--- a/src/pjrt_plugin/ops/handler_utils.h
+++ b/src/pjrt_plugin/ops/handler_utils.h
@@ -190,6 +190,7 @@ void RegisterShapeHandlers(std::unordered_map<std::string, OpHandler>& handlers)
 void RegisterSliceHandlers(std::unordered_map<std::string, OpHandler>& handlers);
 void RegisterGatherScatterHandlers(std::unordered_map<std::string, OpHandler>& handlers);
 void RegisterReductionHandlers(std::unordered_map<std::string, OpHandler>& handlers);
+void RegisterCollectivesHandlers(std::unordered_map<std::string, OpHandler>& handlers);
 void RegisterLinalgHandlers(std::unordered_map<std::string, OpHandler>& handlers);
 void RegisterControlFlowHandlers(std::unordered_map<std::string, OpHandler>& handlers);
 void RegisterSortFftComplexHandlers(std::unordered_map<std::string, OpHandler>& handlers);

--- a/src/pjrt_plugin/ops/reduction.cc
+++ b/src/pjrt_plugin/ops/reduction.cc
@@ -625,48 +625,12 @@ bool HandleSelectAndScatter(mlir::Operation* op, ValueMap& values,
     return true;
 }
 
-// Handler for stablehlo.all_reduce.
-//
-// This is a single-device/debug fallback: bypass the collective and forward each
-// operand as the corresponding result. Multi-device collectives must fail
-// loudly; treating them as identity would silently produce wrong values.
-bool HandleAllReduce(mlir::Operation* op, ValueMap& values, std::vector<mlx::core::array>& outputs,
-                     ExecContext& ctx) {
-    auto replicaGroups = op->getAttrOfType<mlir::DenseIntElementsAttr>("replica_groups");
-    if (replicaGroups && !replicaGroups.empty()) {
-        auto groupType = mlir::dyn_cast<mlir::RankedTensorType>(replicaGroups.getType());
-        bool isMultiDevice = (!groupType || groupType.getRank() < 2)
-                                 ? replicaGroups.getNumElements() > 1
-                                 : groupType.getShape().back() > 1;
-        if (isMultiDevice) {
-            ctx.error_message = "stablehlo.all_reduce: multi-device all_reduce is not supported";
-            MPS_LOG_ERROR("%s\n", ctx.error_message.c_str());
-            return false;
-        }
-    }
-
-    if (op->getNumOperands() != op->getNumResults()) {
-        ctx.error_message = "stablehlo.all_reduce: operand/result count mismatch";
-        MPS_LOG_ERROR("%s\n", ctx.error_message.c_str());
-        return false;
-    }
-
-    for (unsigned i = 0; i < op->getNumOperands(); ++i) {
-        auto* input = RequireValue(values, op->getOperand(i), "stablehlo.all_reduce");
-        if (!input)
-            return false;
-        values.emplace(ToKey(op->getResult(i)), *input);
-    }
-    return true;
-}
-
 }  // namespace
 
 void RegisterReductionHandlers(std::unordered_map<std::string, OpHandler>& handlers) {
     handlers.insert({"stablehlo.reduce", HandleReduce});
     handlers.insert({"stablehlo.reduce_window", HandleReduceWindow});
     handlers.insert({"stablehlo.select_and_scatter", HandleSelectAndScatter});
-    handlers.insert({"stablehlo.all_reduce", HandleAllReduce});
 }
 
 }  // namespace jax_mps

--- a/tests/configs/__init__.py
+++ b/tests/configs/__init__.py
@@ -1,5 +1,6 @@
 from .benchmark import make_benchmark_op_configs
 from .binary import make_binary_op_configs
+from .collectives import make_collectives_op_configs
 from .control_flow import make_control_flow_op_configs
 from .conv import make_conv_op_configs
 from .conversion import make_conversion_op_configs
@@ -24,6 +25,7 @@ __all__ = [
     "OperationTestConfig",
     "make_benchmark_op_configs",
     "make_binary_op_configs",
+    "make_collectives_op_configs",
     "make_control_flow_op_configs",
     "make_conv_op_configs",
     "make_conversion_op_configs",

--- a/tests/configs/collectives.py
+++ b/tests/configs/collectives.py
@@ -27,9 +27,7 @@ def _partition_id_axis_index(x):
     pmapped axis index is 0 and this function is an identity.
     """
     dev = getattr(jax.config, "jax_default_device", None) or jax.devices()[0]
-    return jax.pmap(
-        lambda y: y + lax.axis_index("i"), axis_name="i", devices=[dev]
-    )(x)
+    return jax.pmap(lambda y: y + lax.axis_index("i"), axis_name="i", devices=[dev])(x)
 
 
 def make_collectives_op_configs():

--- a/tests/configs/collectives.py
+++ b/tests/configs/collectives.py
@@ -1,0 +1,54 @@
+import jax
+from jax import lax, random
+from jax import numpy as jnp
+
+from .util import OperationTestConfig
+
+
+def _all_reduce_pmean(x):
+    """Single-device pmean, lowering to stablehlo.all_reduce (issue #201).
+
+    pmap ignores jax.default_device, so pin it to the harness's current default
+    device; otherwise the collective always runs on the default (MPS) backend and
+    the CPU comparison pass fails its device-placement assertion.
+    """
+    # getattr: jax.config exposes jax_default_device at runtime but pyright's
+    # stubs don't declare it.
+    dev = getattr(jax.config, "jax_default_device", None) or jax.devices()[0]
+    return jax.pmap(
+        lambda y: lax.pmean(y, axis_name="i"), axis_name="i", devices=[dev]
+    )(x)
+
+
+def _partition_id_axis_index(x):
+    """Single-device axis_index, lowering to stablehlo.partition_id.
+
+    With one process and one partition, partition_id is 0; therefore the
+    pmapped axis index is 0 and this function is an identity.
+    """
+    dev = getattr(jax.config, "jax_default_device", None) or jax.devices()[0]
+    return jax.pmap(
+        lambda y: y + lax.axis_index("i"), axis_name="i", devices=[dev]
+    )(x)
+
+
+def make_collectives_op_configs():
+    with OperationTestConfig.module_name("collectives"):
+        # stablehlo.all_reduce: single-device identity fallback (issue #201).
+        # pmap over one device emits all_reduce with a 1x1 replica_groups; the
+        # handler forwards operand -> result. The pmean VJP is itself an
+        # all_reduce, so the default grad path exercises the handler on the
+        # backward pass too.
+        yield OperationTestConfig(
+            _all_reduce_pmean,
+            lambda key: random.normal(key, (1, 4)),
+            name="all_reduce-pmean-identity",
+        )
+        # stablehlo.partition_id: single-partition zero fallback. The StableHLO
+        # op is operand-free by spec; this test covers the normal JAX lowering
+        # via pmap axis_index rather than malformed IR validation.
+        yield OperationTestConfig(
+            _partition_id_axis_index,
+            lambda key: jnp.arange(4, dtype=jnp.int32).reshape(1, 4),
+            name="partition_id-axis_index-zero",
+        )

--- a/tests/configs/reduction.py
+++ b/tests/configs/reduction.py
@@ -1,23 +1,7 @@
-import jax
 from jax import lax, random
 from jax import numpy as jnp
 
 from .util import OperationTestConfig, complex_standard_normal
-
-
-def _all_reduce_pmean(x):
-    """Single-device pmean, lowering to stablehlo.all_reduce (issue #201).
-
-    pmap ignores jax.default_device, so pin it to the harness's current default
-    device; otherwise the collective always runs on the default (MPS) backend and
-    the CPU comparison pass fails its device-placement assertion.
-    """
-    # getattr: jax.config exposes jax_default_device at runtime but pyright's
-    # stubs don't declare it.
-    dev = getattr(jax.config, "jax_default_device", None) or jax.devices()[0]
-    return jax.pmap(
-        lambda y: lax.pmean(y, axis_name="i"), axis_name="i", devices=[dev]
-    )(x)
 
 
 def make_reduction_op_configs():
@@ -98,17 +82,6 @@ def make_reduction_op_configs():
             lambda x: lax.reduce_window(x, 0.0, lax.add, (), (), "valid"),
             lambda key: random.normal(key, ()),
             name="reduce_window_scalar",
-        )
-
-    # stablehlo.all_reduce: single-device identity fallback (issue #201). pmap
-    # over one device emits all_reduce with a 1x1 replica_groups; the handler
-    # forwards operand -> result. The pmean VJP is itself an all_reduce, so the
-    # default grad path exercises the handler on the backward pass too.
-    with OperationTestConfig.module_name("reduction-real"):
-        yield OperationTestConfig(
-            _all_reduce_pmean,
-            lambda key: random.normal(key, (1, 4)),
-            name="all_reduce-pmean-identity",
         )
 
     # Pooling operations (lower to stablehlo.reduce_window with pooling pattern).

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -9,6 +9,7 @@ from jax import numpy as jnp
 from .configs import (
     OperationTestConfig,
     make_binary_op_configs,
+    make_collectives_op_configs,
     make_control_flow_op_configs,
     make_conv_op_configs,
     make_conversion_op_configs,
@@ -48,6 +49,7 @@ def get_test_platforms() -> list[str]:
 
 OPERATION_TEST_CONFIGS = [
     *make_binary_op_configs(),
+    *make_collectives_op_configs(),
     *make_control_flow_op_configs(),
     *make_conv_op_configs(),
     *make_conversion_op_configs(),


### PR DESCRIPTION
This PR does two things:

* Adds a handler for `stablehlo.partition_id`. On single device, this is the device ID(0). Multi-partition modules are rejected. 
* Since this gets invoked in collective context, this op, alongwith `stablehlo.all_reduce` handling is migrated to `ops/collectives.cc`

Testing:
* Updated the unsupported-test skip pattern so `all_reduce` and `partition_id` are no longer treated as unsupported (unhandled, should I say) collectives.
* Added collectives test configs for single-device `lax.pmean` and `lax.axis_index`, and wired them into the main op test suite.
* Moved the existing all-reduce test out of reduction configs into the new collectives configs.

This will close #213.