### PR TITLE
test(collectives): drop replica_id from unsupported skip pattern

### DIFF
--- a/scripts/_pytest_skip_unsupported_plugin.py
+++ b/scripts/_pytest_skip_unsupported_plugin.py
@@ -66,18 +66,22 @@ _UNSUPPORTED_PATTERNS: list[tuple[re.Pattern[str], str]] = [
         re.compile(r"failed to find a local CPU device"),
         "jax-mps exposes only the 'mps' platform; no local CPU device available",
     ),
-    # Collective ops require a multi-device mesh; MPS presents a single device.
-    # Match the specific collective op names inside the "Unsupported operation(s)"
+    # Genuine multi-device collectives require a mesh; MPS presents a single
+    # device, so cross-device communication is fundamentally unavailable. Match
+    # the specific collective op names inside the "Unsupported operation(s)"
     # message so generic missing-handler failures stay visible.
     #
-    # replica_id has no handler: current JAX lowers axis_index to partition_id
-    # (handled), leaving replica_id unreachable, so it stays skip-listed as a
-    # forward-looking guard in case a future lowering revives the replica path.
+    # Deliberately excludes partition_id/replica_id: those aren't collectives,
+    # they report the current device's position, which on one device is a
+    # trivially implementable 0 (partition_id already has a handler). Skip-listing
+    # replica_id would mask a *fixable* missing handler -- if a future JAX lowering
+    # ever emits it, we want a loud failure that prompts adding the handler, not a
+    # silent skip.
     (
         re.compile(
             r"Unsupported operation\(s\): stablehlo\."
             r"(all_gather|all_to_all|collective_permute|"
-            r"collective_broadcast|reduce_scatter|replica_id)"
+            r"collective_broadcast|reduce_scatter)"
         ),
         "collective ops require a multi-device mesh; MPS is single-device",
     ),


### PR DESCRIPTION
Follow-up to #214.

That PR briefly re-added `replica_id` to the unsupported-op skip regex in
`scripts/_pytest_skip_unsupported_plugin.py` as a "forward-looking guard". That
inverts the plugin's contract. The skip-list exists to drop tests from the
badge pass-rate denominator **only** when MPS *fundamentally* cannot provide a
capability (float64, a CPU device, genuine multi-device collectives) — never
for a missing handler we could implement. Its docstring is explicit: *"not
missing handlers we could implement"* and *"we never silently mask a fixable
failure (a missing op handler, …)"*.

`replica_id` is not a collective — it reports the current device's position,
which on a single device is a trivially implementable `0`, exactly like
`partition_id` (already handled). Skip-listing it would silently mask a fixable
failure: if a future JAX lowering ever emits `stablehlo.replica_id`, we want a
loud failure that prompts adding the ~10-line handler, not a vanish-as-skip.

This restores the state #214's author originally intended (`…|reduce_scatter)`,
no `replica_id`).

## Effect
None on the current suite: `replica_id` is unreachable in current JAX
(`lax.axis_index` lowers to `partition_id`; the `replica_id` branch in
`lax.parallel` is dead — `ReplicaAxisContext` no longer exists), so nothing
emits it either way. This only restores the correct loud-failure behavior for
the future.

## Testing
Docs/pattern-only change under `scripts/`; no op or handler behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)